### PR TITLE
thumbnail resize bug?

### DIFF
--- a/imagick_helpers.c
+++ b/imagick_helpers.c
@@ -68,12 +68,12 @@ zend_bool php_imagick_thumbnail_dimensions(MagickWand *magick_wand, zend_bool be
 
 		ratio_x = (double)desired_width / (double)orig_width; 
 		ratio_y = (double)desired_height / (double)orig_height; 
-		
-                //in the case of square images there should be no rounding error
-                if (ratio_x == ratio_y) {
-                    *new_width  = desired_width;
-                    *new_height = desired_height;
-                } else if (ratio_x < ratio_y) { 
+
+		//in the case of square images there should be no rounding error
+		if (ratio_x == ratio_y) {
+			*new_width  = desired_width;
+			*new_height = desired_height;
+		} else if (ratio_x < ratio_y) { 
 			*new_width  = desired_width;
 			*new_height = ratio_x * (double)orig_height; 
 		} else { 


### PR DESCRIPTION
I found some interesting behaviour in the Imagick thumbnail creation function. Namely that when I resized square sized images into smaller sized square images (like 300x300 into 220x220) they lost a pixel (like they became 219x220). I think it might be due the fact that in `imagick_helpers.c` one side of the image is _always_ calculated from the original size and a ratio which is a `double`. So I added another branch to the `if` for square images where the size isn't calculated, the destined width and height is used.

**CAUTION**
I couldn't test my code. Use it with care!
