### PR TITLE
Fix wrong type_spec in getPixelRegionIterator

### DIFF
--- a/imagickpixeliterator_class.c
+++ b/imagickpixeliterator_class.c
@@ -289,7 +289,7 @@ PHP_METHOD(imagickpixeliterator, getpixelregioniterator)
 	long x, y, columns, rows;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "O", &magick_object, php_imagick_sc_entry, &x, &y, &columns, &rows) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Ollll", &magick_object, php_imagick_sc_entry, &x, &y, &columns, &rows) == FAILURE) {
 		return;
 	}
 


### PR DESCRIPTION
Fix following bug:

``` php
$magick = new Imagick('magick:rose');
$iterator = ImagickPixelIterator::getPixelRegionIterator($magick, 1, 1, 1, 1);
$iterator = ImagickPixelIterator::getPixelRegionIterator($magick);
```

output

```
PHP Warning:  ImagickPixelIterator::getpixelregioniterator() expects exactly 1 parameter, 5 given in /tmp/bug.php on line 3
php: zero region size `Q16' @ error/pixel-iterator.c/NewPixelRegionIterator/430.
```
