### PR TITLE
Added version check.

### DIFF
--- a/imagick.c
+++ b/imagick.c
@@ -2767,22 +2767,32 @@ static int checkImagickVersion()
 	size_t imagickVersion = MagickLibVersion;
 
 	//This gets the version of Image Magick that has been loaded
-	char * imageMagickLibraryVersionString;
 	size_t imageMagickLibraryVersion;
-	imageMagickLibraryVersionString = GetMagickVersion(&imageMagickLibraryVersion);
 
-	if (imagickVersion != imageMagickLibraryVersion) {
-		zend_error(
-			E_ERROR,
-			"Version mismatch detected. Image Magick library version %s is being used, but Imagick was compiled against version %s.",
-			imageMagickLibraryVersionString,
-			MagickLibVersionText
-		);
+	GetMagickVersion(&imageMagickLibraryVersion);
 
-		return FAILURE;
+	if (imagickVersion == imageMagickLibraryVersion) {
+		return SUCCESS;
 	}
 
-	return SUCCESS;
+	if ((imagickVersion & imageMagickLibraryVersion & 0xfff0) != 0) {
+		zend_error(
+			E_WARNING,
+			"Version warning: Imagick was compiled against Image Magick version %x but version %x is loaded. Imagick will run but may behave surprisingly.",
+			imagickVersion,
+			imageMagickLibraryVersion
+		);
+		return SUCCESS;
+	}
+
+	zend_error(
+		E_ERROR,
+		"Version error: Imagick was compiled against Image Magick version %x but version %x is loaded. Imagick will not run.",
+		imagickVersion,
+		imageMagickLibraryVersion
+	);
+
+	return FAILURE;
 }
 
 PHP_MINIT_FUNCTION(imagick)


### PR DESCRIPTION
Added version check to compare the version of Image Magick that Imagick was compiled against, with the version of Image Magick that has been loaded.

Apparently this is an issue on Windows, where people download random pre-compiled libraries:

http://stackoverflow.com/questions/22547819/imagick-not-loading-images-with-nodecodedelegateforthisimageformat-error-mess
http://stackoverflow.com/questions/20444383/magick-nodecodedelegateforthisimageformat
http://stackoverflow.com/questions/2285161/how-do-i-process-jpg-files-using-imagemagick-imagick-api-i-am-getting-an-exce

TBH I'm not sure if the version check should be `!=` or whether the Image Magick guys are careful not to change constants and so newer versions of Image Magick would work when Imagick is compiled against an older version and so it could be `>=`. So I left it as `!=` to be safe.

Also, I have no Windows box to test this. I only tested it by hacking in `imageMagickLibraryVersion += 1;` and it does seem to prevent Imagick running against a wrong version of the library - but that's hardly what I'd call decent testing.
