### PR TITLE
PHP-8 compatibility (more extensive)

### DIFF
--- a/imagick.c
+++ b/imagick.c
@@ -2445,7 +2445,7 @@ static zend_function_entry php_imagick_class_methods[] =
 	PHP_ME(imagick, smushimages, imagick_smushimages_args, ZEND_ACC_PUBLIC)
 #endif
 	PHP_ME(imagick, __construct, imagick_construct_args, ZEND_ACC_PUBLIC|ZEND_ACC_CTOR)
-	PHP_ME(imagick, __tostring, NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, __tostring, imagick_zero_args, ZEND_ACC_PUBLIC)
 #if PHP_VERSION_ID >= 50600
 	PHP_ME(imagick, count, imagick_count_args, ZEND_ACC_PUBLIC)
 #else
@@ -2661,7 +2661,7 @@ static zend_function_entry php_imagick_class_methods[] =
 	PHP_ME(imagick, getimagegamma, imagick_zero_args, ZEND_ACC_PUBLIC)
 	PHP_ME(imagick, getimagegreenprimary, imagick_zero_args, ZEND_ACC_PUBLIC)
 	PHP_ME(imagick, getimageheight, imagick_zero_args, ZEND_ACC_PUBLIC)
-	PHP_ME(imagick, getimagehistogram, NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(imagick, getimagehistogram, imagick_zero_args, ZEND_ACC_PUBLIC)
 	PHP_ME(imagick, getimageinterlacescheme, imagick_zero_args, ZEND_ACC_PUBLIC)
 	PHP_ME(imagick, getimageiterations, imagick_zero_args, ZEND_ACC_PUBLIC)
 #if MagickLibVersion < 0x700

--- a/imagick_helpers.c
+++ b/imagick_helpers.c
@@ -113,7 +113,9 @@ MagickBooleanType php_imagick_progress_monitor_callable(const char *text, const 
 #endif
 	fci.param_count = 2;
 	fci.params = zargs;
+#if PHP_VERSION_ID < 80000
 	fci.no_separation = 0;
+#endif
 #if PHP_VERSION_ID < 70100
 	fci.symbol_table = NULL;
 #endif

--- a/imagick_helpers.c
+++ b/imagick_helpers.c
@@ -806,7 +806,7 @@ PixelWand *php_imagick_zval_to_pixelwand (zval *param, php_imagick_class_type_t 
 		break;
 
 		case IS_OBJECT:
-			if (instanceof_function_ex(Z_OBJCE_P(param), php_imagickpixel_sc_entry, 0 TSRMLS_CC)) {
+			if (instanceof_function(Z_OBJCE_P(param), php_imagickpixel_sc_entry TSRMLS_CC)) {
 				php_imagickpixel_object *intern = Z_IMAGICKPIXEL_P(param);
 				pixel_wand = intern->pixel_wand;
 			} else
@@ -856,7 +856,7 @@ PixelWand *php_imagick_zval_to_opacity (zval *param, php_imagick_class_type_t ca
 		break;
 
 		case IS_OBJECT:
-			if (instanceof_function_ex(Z_OBJCE_P(param), php_imagickpixel_sc_entry, 0 TSRMLS_CC)) {
+			if (instanceof_function(Z_OBJCE_P(param), php_imagickpixel_sc_entry TSRMLS_CC)) {
 				php_imagickpixel_object *intern = Z_IMAGICKPIXEL_P(param);
 				pixel_wand = intern->pixel_wand;
 			} else

--- a/imagickkernel_class.c
+++ b/imagickkernel_class.c
@@ -79,7 +79,11 @@ static void php_imagickkernelvalues_to_zval(zval *zv, KernelInfo *kernel_info) {
 }
 
 
+#if PHP_VERSION_ID >= 80000
+HashTable* php_imagickkernel_get_debug_info(zend_object *obj, int *is_temp TSRMLS_DC) /* {{{ */
+#else
 HashTable* php_imagickkernel_get_debug_info(zval *obj, int *is_temp TSRMLS_DC) /* {{{ */
+#endif
 {
 	php_imagickkernel_object *internp;
 	HashTable *debug_info;
@@ -92,7 +96,11 @@ HashTable* php_imagickkernel_get_debug_info(zval *obj, int *is_temp TSRMLS_DC) /
 
 	*is_temp = 1; //var_dump will destroy the hashtable
 
+#if PHP_VERSION_ID >= 80000
+	internp = php_imagickkernel_fetch_object(obj);
+#else
 	internp = Z_IMAGICKKERNEL_P(obj);
+#endif
 	kernel_info = internp->kernel_info;
 
 	ALLOC_HASHTABLE(debug_info);

--- a/php_imagick_defs.h
+++ b/php_imagick_defs.h
@@ -42,6 +42,16 @@
 #include "php_ini.h"
 #include "Zend/zend.h"
 
+#if PHP_VERSION_ID >= 80000
+	#define HAVE_LOCALE_H
+	#define TSRMLS_C
+	#define TSRMLS_CC
+	#define TSRMLS_D
+	#define TSRMLS_DC
+	#define TSRMLS_FETCH()
+	#define TSRMLS_SET_CTX(ctx)
+#endif
+
 /* Include locale header */
 #ifdef HAVE_LOCALE_H
 # include <locale.h>


### PR DESCRIPTION
This PR is another proposed implementation of #334. Compared to that PR, I have chosen a slightly different approach:

* instead of removing the usages of the TSRM defines, I re-added the empty definitions in order for the code to (potentially) remain compatible with PHP 5. Other checks in the code also provide PHP 5 compatibility so I felt breaking that as part of adding PHP 8 support was not warranted.
* In the same vein, the usage of the `no_separation` field in `zend_fcall_info` is now also checked  based on PHP version.
* this PR also fixes usages of `instanceof_function_ex` which was removed in PHP-8 (by just using `instanceof_function` - in the case of imagick, the two were identical)
* adapt the zend class handlers which are now being called with a `zend_object*` instead of a `zval*`. Not doing this is very likely going to cause segfaults at runtime which is why I recommend having a look at this PR over #334
* adds explicit `imagick_zero_args` arginfo to two methods taking no arguments. PHP-8 is checking arginfo for completeness and is throwing an E_NOTICE if things are incomplete.

The existing code was making heavy use of the `ZEND_ENGINE_3` define. Unfortunately, no equivalent `ZEND_ENGINE_4` define exists (yet?), so I had to fall back to checking `PHP_VERSION_ID`.