### PR TITLE
use PHP_VERSION_ID instead of ZEND_ENGINE_3

### DIFF
--- a/imagick.c
+++ b/imagick.c
@@ -24,7 +24,7 @@
 #include "php_imagick_helpers.h"
 #include "php_imagick_shared.h"
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 #include "ext/standard/php_smart_string.h"
 #else
 #include "ext/standard/php_smart_str.h"
@@ -2891,7 +2891,7 @@ static void php_imagick_object_free_storage(IM_ZEND_OBJECT *object TSRMLS_DC)
 	}
 
 	zend_object_std_dtor(&intern->zo TSRMLS_CC);
-#ifndef ZEND_ENGINE_3
+#if PHP_VERSION_ID < 70000
 	efree(intern);
 #endif
 }
@@ -2911,7 +2911,7 @@ static void php_imagickdraw_object_free_storage(IM_ZEND_OBJECT *object TSRMLS_DC
 
 	zend_object_std_dtor(&intern->zo TSRMLS_CC);
 
-	#ifndef ZEND_ENGINE_3
+	#if PHP_VERSION_ID < 70000
 		efree(intern);
 	#endif
 }
@@ -2929,7 +2929,7 @@ static void php_imagickpixeliterator_object_free_storage(IM_ZEND_OBJECT *object 
 	}
 
 	zend_object_std_dtor(&intern->zo TSRMLS_CC);
-	#ifndef ZEND_ENGINE_3
+	#if PHP_VERSION_ID < 70000
 		efree(intern);
 	#endif
 }
@@ -2947,7 +2947,7 @@ static void php_imagickpixel_object_free_storage(IM_ZEND_OBJECT *object TSRMLS_D
 		intern->pixel_wand = DestroyPixelWand(intern->pixel_wand);
 
 	zend_object_std_dtor(&intern->zo TSRMLS_CC);
-	#ifndef ZEND_ENGINE_3
+	#if PHP_VERSION_ID < 70000
 		efree(intern);
 	#endif
 }
@@ -2968,7 +2968,7 @@ static void php_imagickkernel_object_free_storage(IM_ZEND_OBJECT *object TSRMLS_
 	}
 
 	zend_object_std_dtor(&intern->zo TSRMLS_CC);
-#ifndef ZEND_ENGINE_3
+#if PHP_VERSION_ID < 70000
 	efree(intern);
 #endif
 }
@@ -2986,7 +2986,7 @@ static void php_imagickkernel_object_free_storage(IM_ZEND_OBJECT *object TSRMLS_
 		 }
 #endif
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 static zend_object * php_imagick_object_new_ex(zend_class_entry *class_type, php_imagick_object **ptr, zend_bool init_wand TSRMLS_DC)
 #else
 static zend_object_value php_imagick_object_new_ex(zend_class_entry *class_type, php_imagick_object **ptr, zend_bool init_wand TSRMLS_DC)
@@ -2996,7 +2996,7 @@ static zend_object_value php_imagick_object_new_ex(zend_class_entry *class_type,
 	php_imagick_object *intern;
 
 	/* Allocate memory for it */
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	intern = ecalloc(1,
 		sizeof(php_imagick_object) +
 		zend_object_properties_size(class_type));
@@ -3035,7 +3035,7 @@ static zend_object_value php_imagick_object_new_ex(zend_class_entry *class_type,
 	zend_object_std_init(&intern->zo, class_type TSRMLS_CC);
 	object_properties_init(&intern->zo, class_type);
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	intern->zo.handlers = &imagick_object_handlers;
 	return &intern->zo;
 #else
@@ -3046,7 +3046,7 @@ static zend_object_value php_imagick_object_new_ex(zend_class_entry *class_type,
 }
 
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 static zend_object * php_imagick_object_new(zend_class_entry *class_type TSRMLS_DC)
 #else
 static zend_object_value php_imagick_object_new(zend_class_entry *class_type TSRMLS_DC)
@@ -3055,7 +3055,7 @@ static zend_object_value php_imagick_object_new(zend_class_entry *class_type TSR
 	return php_imagick_object_new_ex(class_type, NULL, 1 TSRMLS_CC);
 }
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 static zend_object * php_imagickdraw_object_new_ex(zend_class_entry *class_type, php_imagickdraw_object **ptr, zend_bool init_wand TSRMLS_DC)
 #else
 static zend_object_value php_imagickdraw_object_new_ex(zend_class_entry *class_type, php_imagickdraw_object **ptr, zend_bool init_wand TSRMLS_DC)
@@ -3063,7 +3063,7 @@ static zend_object_value php_imagickdraw_object_new_ex(zend_class_entry *class_t
 {
 	php_imagickdraw_object *intern;
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	/* Allocate memory for it */
 	intern = ecalloc(1,
 		sizeof(php_imagickdraw_object) +
@@ -3092,7 +3092,7 @@ static zend_object_value php_imagickdraw_object_new_ex(zend_class_entry *class_t
 	} else {
 		intern->drawing_wand = NULL;
 	}
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	intern->zo.handlers = &imagickdraw_object_handlers;
 
 	return &intern->zo;
@@ -3107,7 +3107,7 @@ static zend_object_value php_imagickdraw_object_new_ex(zend_class_entry *class_t
 #endif
 }
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 static zend_object * php_imagickdraw_object_new(zend_class_entry *class_type TSRMLS_DC)
 #else
 static zend_object_value php_imagickdraw_object_new(zend_class_entry *class_type TSRMLS_DC)
@@ -3116,7 +3116,7 @@ static zend_object_value php_imagickdraw_object_new(zend_class_entry *class_type
 	return php_imagickdraw_object_new_ex(class_type, NULL, 1 TSRMLS_CC);
 }
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 static zend_object * php_imagickpixeliterator_object_new(zend_class_entry *class_type TSRMLS_DC)
 #else
 static zend_object_value php_imagickpixeliterator_object_new(zend_class_entry *class_type TSRMLS_DC)
@@ -3125,7 +3125,7 @@ static zend_object_value php_imagickpixeliterator_object_new(zend_class_entry *c
 	php_imagickpixeliterator_object *intern;
 
 	/* Allocate memory for it */
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	intern = ecalloc(1,
 			sizeof(php_imagickpixeliterator_object) +
 			zend_object_properties_size(class_type));
@@ -3147,7 +3147,7 @@ static zend_object_value php_imagickpixeliterator_object_new(zend_class_entry *c
 	zend_object_std_init(&intern->zo, class_type TSRMLS_CC);
 	object_properties_init(&intern->zo, class_type);
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	intern->zo.handlers = &imagickpixeliterator_object_handlers;
 
 	return &intern->zo;
@@ -3159,7 +3159,7 @@ static zend_object_value php_imagickpixeliterator_object_new(zend_class_entry *c
 #endif
 }
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 static zend_object * php_imagickpixel_object_new_ex(zend_class_entry *class_type, php_imagickpixel_object **ptr TSRMLS_DC)
 #else
 static zend_object_value php_imagickpixel_object_new_ex(zend_class_entry *class_type, php_imagickpixel_object **ptr TSRMLS_DC)
@@ -3167,7 +3167,7 @@ static zend_object_value php_imagickpixel_object_new_ex(zend_class_entry *class_
 {
 	php_imagickpixel_object *intern;
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	/* Allocate memory for it */
 	intern = ecalloc(1,
 		sizeof(php_imagickpixel_object) +
@@ -3188,7 +3188,7 @@ static zend_object_value php_imagickpixel_object_new_ex(zend_class_entry *class_
 	zend_object_std_init(&intern->zo, class_type TSRMLS_CC);
 	object_properties_init(&intern->zo, class_type);
 	
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	intern->zo.handlers = &imagickpixel_object_handlers;
 
 	return &intern->zo;
@@ -3201,7 +3201,7 @@ static zend_object_value php_imagickpixel_object_new_ex(zend_class_entry *class_
 
 }
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 static zend_object * php_imagickpixel_object_new(zend_class_entry *class_type TSRMLS_DC)
 #else
 static zend_object_value php_imagickpixel_object_new(zend_class_entry *class_type TSRMLS_DC)
@@ -3212,7 +3212,7 @@ static zend_object_value php_imagickpixel_object_new(zend_class_entry *class_typ
 
 #ifdef IMAGICK_WITH_KERNEL
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 static zend_object *  php_imagickkernel_object_new_ex(zend_class_entry *class_type, php_imagickkernel_object **ptr TSRMLS_DC)
 #else
 static zend_object_value php_imagickkernel_object_new_ex(zend_class_entry *class_type, php_imagickkernel_object **ptr TSRMLS_DC)
@@ -3222,7 +3222,7 @@ static zend_object_value php_imagickkernel_object_new_ex(zend_class_entry *class
 	php_imagickkernel_object *intern;
 
 	/* Allocate memory for it */
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	intern = ecalloc(1,
 		sizeof(php_imagickkernel_object) +
 		zend_object_properties_size(class_type));
@@ -3243,7 +3243,7 @@ static zend_object_value php_imagickkernel_object_new_ex(zend_class_entry *class
 	zend_object_std_init(&intern->zo, class_type TSRMLS_CC);
 	object_properties_init(&intern->zo, class_type);
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	intern->zo.handlers = &imagickkernel_object_handlers;
 
 	return &intern->zo;
@@ -3259,7 +3259,7 @@ static zend_object_value php_imagickkernel_object_new_ex(zend_class_entry *class
 #undef object_properties_init
 
 #ifdef IMAGICK_WITH_KERNEL
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 static zend_object * php_imagickkernel_object_new(zend_class_entry *class_type TSRMLS_DC)
 #else
 static zend_object_value php_imagickkernel_object_new(zend_class_entry *class_type TSRMLS_DC)
@@ -3374,7 +3374,7 @@ static zval *php_imagick_read_property(zend_object *object, zend_string *member,
 
 #else // PHP_VERSION_ID >= 80000
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 static zval *php_imagick_read_property(zval *object, zval *member, int type, void **cache_slot, zval *rv TSRMLS_DC)
 {
 	int ret;
@@ -3734,7 +3734,7 @@ PHP_MINIT_FUNCTION(imagick)
 		Initialize exceptions (Imagick exception)
 	*/
 	INIT_CLASS_ENTRY(ce, PHP_IMAGICK_EXCEPTION_SC_NAME, NULL);
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	php_imagick_exception_class_entry = zend_register_internal_class_ex(&ce, zend_ce_exception);
 #else
 	php_imagick_exception_class_entry = zend_register_internal_class_ex(&ce, zend_exception_get_default(TSRMLS_C), NULL TSRMLS_CC);
@@ -3744,7 +3744,7 @@ PHP_MINIT_FUNCTION(imagick)
 	Initialize exceptions (ImagickDraw exception)
 	*/
 	INIT_CLASS_ENTRY(ce, PHP_IMAGICKDRAW_EXCEPTION_SC_NAME, NULL);
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	php_imagickdraw_exception_class_entry = zend_register_internal_class_ex(&ce, zend_ce_exception);
 #else
 	php_imagickdraw_exception_class_entry = zend_register_internal_class_ex(&ce, zend_exception_get_default(TSRMLS_C), NULL TSRMLS_CC);
@@ -3754,7 +3754,7 @@ PHP_MINIT_FUNCTION(imagick)
 	Initialize exceptions (ImagickPixelIterator exception)
 	*/
 	INIT_CLASS_ENTRY(ce, PHP_IMAGICKPIXELITERATOR_EXCEPTION_SC_NAME, NULL);
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	php_imagickpixeliterator_exception_class_entry = zend_register_internal_class_ex(&ce, zend_ce_exception);
 #else
 	php_imagickpixeliterator_exception_class_entry = zend_register_internal_class_ex(&ce, zend_exception_get_default(TSRMLS_C), NULL TSRMLS_CC);
@@ -3764,7 +3764,7 @@ PHP_MINIT_FUNCTION(imagick)
 	Initialize exceptions (ImagickPixel exception)
 	*/
 	INIT_CLASS_ENTRY(ce, PHP_IMAGICKPIXEL_EXCEPTION_SC_NAME, NULL);
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	php_imagickpixel_exception_class_entry = zend_register_internal_class_ex(&ce, zend_ce_exception);
 #else
 	php_imagickpixel_exception_class_entry = zend_register_internal_class_ex(&ce, zend_exception_get_default(TSRMLS_C), NULL TSRMLS_CC);
@@ -3775,7 +3775,7 @@ PHP_MINIT_FUNCTION(imagick)
 	Initialize exceptions (ImagickKernel exception)
 	*/
 	INIT_CLASS_ENTRY(ce, PHP_IMAGICKKERNEL_EXCEPTION_SC_NAME, NULL);
-	#ifdef ZEND_ENGINE_3
+	#if PHP_VERSION_ID >= 70000
 	php_imagickkernel_exception_class_entry = zend_register_internal_class_ex(&ce, zend_ce_exception);
     #else
 	php_imagickkernel_exception_class_entry = zend_register_internal_class_ex(&ce, zend_exception_get_default(TSRMLS_C), NULL TSRMLS_CC);
@@ -3791,7 +3791,7 @@ PHP_MINIT_FUNCTION(imagick)
 	imagick_object_handlers.clone_obj = php_imagick_clone_imagick_object;
 	imagick_object_handlers.read_property = php_imagick_read_property;
 	imagick_object_handlers.count_elements = php_imagick_count_elements;
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	imagick_object_handlers.offset = XtOffsetOf(php_imagick_object, zo);
 	imagick_object_handlers.free_obj = php_imagick_object_free_storage;
 #endif
@@ -3805,7 +3805,7 @@ PHP_MINIT_FUNCTION(imagick)
 	INIT_CLASS_ENTRY(ce, PHP_IMAGICKDRAW_SC_NAME, php_imagickdraw_class_methods);
 	ce.create_object = php_imagickdraw_object_new;
 	imagickdraw_object_handlers.clone_obj = php_imagick_clone_imagickdraw_object;
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	imagickdraw_object_handlers.offset = XtOffsetOf(php_imagickdraw_object, zo);
 	imagickdraw_object_handlers.free_obj = php_imagickdraw_object_free_storage;
 #endif
@@ -3817,7 +3817,7 @@ PHP_MINIT_FUNCTION(imagick)
 	INIT_CLASS_ENTRY(ce, PHP_IMAGICKPIXELITERATOR_SC_NAME, php_imagickpixeliterator_class_methods);
 	ce.create_object = php_imagickpixeliterator_object_new;
 	imagickpixeliterator_object_handlers.clone_obj = NULL;
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	imagickpixeliterator_object_handlers.offset = XtOffsetOf(php_imagickpixeliterator_object, zo);
 	imagickpixeliterator_object_handlers.free_obj = php_imagickpixeliterator_object_free_storage;
 #endif
@@ -3830,7 +3830,7 @@ PHP_MINIT_FUNCTION(imagick)
 	INIT_CLASS_ENTRY(ce, PHP_IMAGICKPIXEL_SC_NAME, php_imagickpixel_class_methods);
 	ce.create_object = php_imagickpixel_object_new;
 	imagickpixel_object_handlers.clone_obj = php_imagick_clone_imagickpixel_object;
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	imagickpixel_object_handlers.offset = XtOffsetOf(php_imagickpixel_object, zo);
 	imagickpixel_object_handlers.free_obj = php_imagickpixel_object_free_storage;
 #endif
@@ -3846,7 +3846,7 @@ PHP_MINIT_FUNCTION(imagick)
 	// Disabled until can be compiled under wall correctly
 	imagickkernel_object_handlers.get_debug_info = php_imagickkernel_get_debug_info;
 	imagickkernel_object_handlers.clone_obj = php_imagick_clone_imagickkernel_object;
-	#ifdef ZEND_ENGINE_3
+	#if PHP_VERSION_ID >= 70000
 	imagickkernel_object_handlers.offset = XtOffsetOf(php_imagickkernel_object, zo);
 	imagickkernel_object_handlers.free_obj = php_imagickkernel_object_free_storage;
     #endif
@@ -3877,7 +3877,7 @@ PHP_MINIT_FUNCTION(imagick)
 PHP_MINFO_FUNCTION(imagick)
 {
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	smart_string formats = {0};
 #else
 	smart_str formats = {0};
@@ -3913,7 +3913,7 @@ PHP_MINFO_FUNCTION(imagick)
 
 	if (supported_formats) {
 		for (i = 0; i < num_formats; i++) {
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 			if (i != 0) {
  				smart_string_appends(&formats, ", ");
 			}
@@ -3927,7 +3927,7 @@ PHP_MINFO_FUNCTION(imagick)
 			IMAGICK_FREE_MAGICK_MEMORY(supported_formats[i]);
 		}
 		
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 		smart_string_0(&formats);
 		php_info_print_table_row(2, "ImageMagick supported formats", formats.c);
 		smart_string_free(&formats);

--- a/imagick_class.c
+++ b/imagick_class.c
@@ -44,7 +44,7 @@ PHP_METHOD(imagick, pingimagefile)
 
 	intern = Z_IMAGICK_P(getThis());
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	php_stream_from_zval(stream, zstream);
 #else
 	php_stream_from_zval(stream, &zstream);
@@ -1044,7 +1044,7 @@ PHP_METHOD(imagick, identifyformat)
 	image_info = DestroyImageInfo(image_info);
 
 	if (result) {
-#ifdef ZEND_ENGINE_3 
+#if PHP_VERSION_ID >= 70000
 		RETVAL_STRING(result);
 #else
 		RETVAL_STRING(result, 1);
@@ -1431,7 +1431,7 @@ PHP_METHOD(imagick, getimageprofiles)
 		for (i = 0; i < profiles_count; i++) {
 
 			profile = (char *)MagickGetImageProfile(intern->magick_wand, profiles[i], &length);
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 			add_assoc_stringl(return_value, profiles[i], profile, length);
 #else
 			add_assoc_stringl(return_value, profiles[i], profile, length, 1);
@@ -1524,7 +1524,7 @@ PHP_METHOD(imagick, writeimagefile)
 		efree (buffer);
 	}
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	php_stream_from_zval(stream, zstream);
 #else
 	php_stream_from_zval(stream, &zstream);
@@ -1579,7 +1579,7 @@ PHP_METHOD(imagick, writeimagesfile)
 		efree (buffer);
 	}
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	php_stream_from_zval(stream, zstream);
 #else
 	php_stream_from_zval(stream, &zstream);
@@ -3048,7 +3048,7 @@ PHP_METHOD(imagick, getimageartifact)
 		php_imagick_convert_imagick_exception(intern->magick_wand, "Unable to get image artifact" TSRMLS_CC);
 		return;
 	}
-#ifdef ZEND_ENGINE_3 
+#if PHP_VERSION_ID >= 70000
 	RETVAL_STRING(value);
 #else
 	RETVAL_STRING(value, 1);
@@ -3189,7 +3189,7 @@ PHP_METHOD(imagick, smushimages)
 /* {{{ proto Imagick Imagick::__construct([mixed files] )
    The Imagick constructor
 */
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 PHP_METHOD(imagick, __construct)
 {
 	php_imagick_object *intern;
@@ -3471,7 +3471,7 @@ PHP_METHOD(imagick, queryfontmetrics)
 		}
 	} else {
 		convert_to_boolean(multiline);
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 		if (Z_TYPE_P(multiline) == IS_TRUE) {
 			query_multiline = 1;
 		}
@@ -3525,7 +3525,7 @@ PHP_METHOD(imagick, queryfontmetrics)
 		return;
 	} else {
 		zval *pbounding;
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 		zval bounding;
 		pbounding = &bounding;
 #else
@@ -3630,7 +3630,7 @@ PHP_METHOD(imagick, readimage)
 /* {{{ proto bool Imagick::readImages(array files )
     Reads image from an array of filenames
 */
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 PHP_METHOD(imagick, readimages)
 {
 
@@ -3759,7 +3759,7 @@ PHP_METHOD(imagick, readimagefile)
 
 	intern = Z_IMAGICK_P(getThis());
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	php_stream_from_zval(stream, zstream);
 #else
 	php_stream_from_zval(stream, &zstream);
@@ -6781,7 +6781,7 @@ PHP_METHOD(imagick, getimagechannelmean)
 */
 PHP_METHOD(imagick, getimagechannelstatistics)
 {
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	zval tmp;
 #else
  	zval *tmp;
@@ -6820,7 +6820,7 @@ PHP_METHOD(imagick, getimagechannelstatistics)
 
 #if MagickLibVersion >= 0x700
 	for (i=0; i < sizeof(channels)/sizeof(channels[0]); i++) {
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 		ZVAL_NEW_ARR(&tmp);
 		array_init(&tmp);
 		add_assoc_double(&tmp, "mean", statistics[i].mean);
@@ -6848,7 +6848,7 @@ PHP_METHOD(imagick, getimagechannelstatistics)
 	}
 #else //below MagickLibVersion>= 0x700
 	for (i = 0; i < elements ; i++) {
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 		ZVAL_NEW_ARR(&tmp);
 		array_init(&tmp);
 		add_assoc_double(&tmp, "mean", statistics[channels[i]].mean);
@@ -7200,7 +7200,7 @@ PHP_METHOD(imagick, getimagehistogram)
 	PixelWand **wand_array;
 	size_t colors = 0;
 	unsigned long i;
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	zval tmp_pixelwand;
 #else
 	zval *tmp_pixelwand;
@@ -7220,7 +7220,7 @@ PHP_METHOD(imagick, getimagehistogram)
 
 	for (i = 0; i < colors; i++) {
 		if (wand_array[i]) {
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 			object_init_ex(&tmp_pixelwand, php_imagickpixel_sc_entry);
 			internp = Z_IMAGICKPIXEL_P(&tmp_pixelwand);
 			php_imagick_replace_pixelwand(internp, wand_array[i]);
@@ -8495,7 +8495,7 @@ void s_add_named_strings (zval *array, const char *haystack TSRMLS_DC)
 	char *last_ptr = NULL, *buffer;
 	size_t num_keys;
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	zend_string    *trim;
 	zend_string    *line_string;
 #else
@@ -8533,7 +8533,7 @@ void s_add_named_strings (zval *array, const char *haystack TSRMLS_DC)
 	while ((found < num_keys) && line) {
 		// Break the line further into tokens
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 		line_string = zend_string_init(line, strlen(line), 0);
 		//str, what, what_len, mode
 		trim = php_trim(line_string, NULL, 0, 3);
@@ -8576,7 +8576,7 @@ PHP_METHOD(imagick, identifyimage)
 	zend_bool append_raw_string = 0;
 	double x, y;
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	zval array;
 #else
 	zval *array;
@@ -8624,7 +8624,7 @@ PHP_METHOD(imagick, identifyimage)
 
 	// Geometry is an associative array
 	
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	ZVAL_NEW_ARR(&array);
 	pArray = &array;
 #else
@@ -8639,7 +8639,7 @@ PHP_METHOD(imagick, identifyimage)
 	add_assoc_zval (return_value, "geometry", pArray);
 
 	if (MagickGetImageResolution(intern->magick_wand, &x, &y) == MagickTrue) {
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 		zval geometry_array;
 		array_init(&geometry_array);
 		add_assoc_double(&geometry_array, "x", x);
@@ -9041,7 +9041,7 @@ PHP_METHOD(imagick, compareimagechannels)
 	php_imagick_object *intern, *intern_second, *intern_return;
 	im_long channel_type, metric_type;
 	double distortion;
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	zval new_wand;
 #else
 	zval *new_wand;
@@ -9069,7 +9069,7 @@ PHP_METHOD(imagick, compareimagechannels)
 		return;
 	}
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	pNewWand = &new_wand;
 #else
 	MAKE_STD_ZVAL(new_wand);
@@ -9372,7 +9372,7 @@ PHP_METHOD(imagick, compareimages)
 	php_imagick_object *intern, *intern_second, *intern_return;
 	im_long metric_type;
 	double distortion;
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	zval new_wand;
 #else
 	zval *new_wand;
@@ -9392,7 +9392,7 @@ PHP_METHOD(imagick, compareimages)
 	if (php_imagick_ensure_not_empty (intern_second->magick_wand) == 0)
 		return;
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	pNewWand = &new_wand;
 #else
 	MAKE_STD_ZVAL(new_wand);
@@ -12044,7 +12044,7 @@ PHP_METHOD(imagick, setprogressmonitor)
 	callback->previous_callback = IMAGICK_G(progress_callback);
 
 	//Add a ref and store the user's callback
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	Z_TRY_ADDREF_P(user_callback);
 	ZVAL_COPY_VALUE(&callback->user_callback, user_callback);
 #else
@@ -12476,7 +12476,7 @@ PHP_METHOD(imagick, subimagematch)
 	im_long metric = 0;
 #endif
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	char *param_string = "O|z/z/dl";
 #else
 	char *param_string = "O|zzdl";

--- a/imagick_file.c
+++ b/imagick_file.c
@@ -160,7 +160,7 @@ static
 int php_imagick_read_image_using_imagemagick(php_imagick_object *intern, struct php_imagick_file_t *file, ImagickOperationType type TSRMLS_DC)
 {
 
-#ifndef ZEND_ENGINE_3
+#if PHP_VERSION_ID < 70000
 #if PHP_VERSION_ID >= 50600
 #ifdef ZTS
 	// This suppresses an 'unused parameter' warning.
@@ -172,7 +172,7 @@ int php_imagick_read_image_using_imagemagick(php_imagick_object *intern, struct 
 	if (type == ImagickReadImage) {
 		if (MagickReadImage(intern->magick_wand, file->filename) == MagickFalse) {
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 			zend_stat_t st;
 #else
 			struct stat st;
@@ -206,7 +206,7 @@ int php_imagick_read_image_using_php_streams(php_imagick_object *intern, struct 
 	IMAGICK_INIT_ERROR_HANDLING;
 	IMAGICK_SET_ERROR_HANDLING_THROW;
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	stream = php_stream_open_wrapper(file->filename, "rb", (IGNORE_PATH) & ~REPORT_ERRORS, NULL);
 #else
 	stream = php_stream_open_wrapper(file->filename, "rb", (ENFORCE_SAFE_MODE|IGNORE_PATH) & ~REPORT_ERRORS, NULL);

--- a/imagick_helpers.c
+++ b/imagick_helpers.c
@@ -55,7 +55,7 @@ void php_imagick_cleanup_progress_callback(php_imagick_callback* progress_callba
 			efree(progress_callback->previous_callback);
 		}
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 		zval_ptr_dtor(&progress_callback->user_callback);
 #else
 		zval_ptr_dtor(&progress_callback->user_callback);
@@ -69,7 +69,7 @@ MagickBooleanType php_imagick_progress_monitor_callable(const char *text, const 
 	zend_fcall_info fci;
 	zend_fcall_info_cache fci_cache;
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	zval zargs[2];
 	zval retval;
 #else
@@ -85,13 +85,13 @@ MagickBooleanType php_imagick_progress_monitor_callable(const char *text, const 
 	// We could maybe use text.
 	(void)text;
 
-#if defined(ZEND_ENGINE_3) && defined(ZTS)
+#if PHP_VERSION_ID >= 70000 && defined(ZTS)
 	if( NULL == tsrm_get_ls_cache() ) {
 		return MagickTrue;
 	}
 #endif
 
-#ifndef ZEND_ENGINE_3
+#if PHP_VERSION_ID < 70000
 	TSRMLS_FETCH_FROM_CTX(callback->thread_ctx);
 #endif
 	fci_cache = empty_fcall_info_cache;
@@ -102,7 +102,7 @@ MagickBooleanType php_imagick_progress_monitor_callable(const char *text, const 
 #if PHP_VERSION_ID < 70100
 	fci.function_table = EG(function_table);
 #endif
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	//fci.function_name = *callback->user_callback;
 	ZVAL_COPY_VALUE(&fci.function_name, &callback->user_callback);
 	fci.retval = &retval;
@@ -114,7 +114,7 @@ MagickBooleanType php_imagick_progress_monitor_callable(const char *text, const 
 	fci.param_count = 2;
 	fci.params = zargs;
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	ZVAL_LONG(&zargs[0], offset);
     ZVAL_LONG(&zargs[1], span);
 #else
@@ -134,7 +134,7 @@ MagickBooleanType php_imagick_progress_monitor_callable(const char *text, const 
 		//Abort processing as user callback is no longer callable
 		return MagickFalse;
 	}
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	if (Z_TYPE(retval) == IS_FALSE) {
 		//User returned false - tell Imagick to abort processing.
 		return MagickFalse;
@@ -285,7 +285,7 @@ double *php_imagick_zval_to_double_array(zval *param_array, im_long *num_element
 	double *double_array;
 	long i = 0;
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	zval *pzvalue;
 #else
 	zval **ppzval;
@@ -299,7 +299,7 @@ double *php_imagick_zval_to_double_array(zval *param_array, im_long *num_element
 
 	double_array = ecalloc(*num_elements, sizeof(double));
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(param_array), pzvalue) {
 		ZVAL_DEREF(pzvalue);
 		double_array[i] = zval_get_double(pzvalue);
@@ -336,7 +336,7 @@ im_long *php_imagick_zval_to_long_array(zval *param_array, im_long *num_elements
 	im_long *long_array;
 	im_long i = 0;
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	zval *pzvalue;
 #else
 	zval **ppzval;
@@ -350,7 +350,7 @@ im_long *php_imagick_zval_to_long_array(zval *param_array, im_long *num_elements
 
 	long_array = ecalloc(*num_elements, sizeof(im_long));
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(param_array), pzvalue) {
 		ZVAL_DEREF(pzvalue);
 		long_array[i] = zval_get_long(pzvalue);
@@ -388,7 +388,7 @@ unsigned char *php_imagick_zval_to_char_array(zval *param_array, im_long *num_el
 	unsigned char *char_array;
 	im_long i = 0;
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	zval *pzvalue;
 #else
 	zval **ppzval;
@@ -402,7 +402,7 @@ unsigned char *php_imagick_zval_to_char_array(zval *param_array, im_long *num_el
 
 	char_array = ecalloc(*num_elements, sizeof(unsigned char));
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(param_array), pzvalue) {
 		ZVAL_DEREF(pzvalue);
 		char_array[i] = zval_get_long(pzvalue);
@@ -538,7 +538,7 @@ PointInfo *php_imagick_zval_to_pointinfo_array(zval *coordinate_array, int *num_
 	long elements, sub_elements, i;
 	HashTable *sub_array;
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	zval *pzvalue;
 #else
 	HashTable *coords;
@@ -558,7 +558,7 @@ PointInfo *php_imagick_zval_to_pointinfo_array(zval *coordinate_array, int *num_
 	*num_elements = elements;
 	coordinates = emalloc(sizeof(PointInfo) * elements);
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(coordinate_array), pzvalue) {
 		zval *pz_x, *pz_y;
 		ZVAL_DEREF(pzvalue);
@@ -770,7 +770,7 @@ PixelWand *php_imagick_zval_to_pixelwand (zval *param, php_imagick_class_type_t 
 	PixelWand *pixel_wand = NULL;
 	*allocated = 0;
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	ZVAL_DEREF(param);
 #endif 
 	if (Z_TYPE_P (param) == IS_LONG || Z_TYPE_P (param) == IS_DOUBLE) {
@@ -818,7 +818,7 @@ PixelWand *php_imagick_zval_to_opacity (zval *param, php_imagick_class_type_t ca
 	PixelWand *pixel_wand = NULL;
 	*allocated = 0;
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	ZVAL_DEREF(param);
 #endif
 	if (Z_TYPE_P (param) == IS_STRING) {

--- a/imagickdraw_class.c
+++ b/imagickdraw_class.c
@@ -155,7 +155,7 @@ PHP_METHOD(imagickdraw, __construct)
 {
 	/* Empty constructor for possible future uses */
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	// This suppresses an 'unused parameter' warning.
 	(void)execute_data;
 	(void)return_value;
@@ -1234,7 +1234,7 @@ PHP_METHOD(imagickdraw, affine)
 	php_imagickdraw_object *internd;
 	zval *affine_matrix;
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	zval *pzval;
 #else
 	HashTable *affine;
@@ -1251,14 +1251,14 @@ PHP_METHOD(imagickdraw, affine)
 		return;
 	}
 
-#ifndef ZEND_ENGINE_3
+#if PHP_VERSION_ID < 70000
 	affine = Z_ARRVAL_P(affine_matrix);
 	zend_hash_internal_pointer_reset_ex(affine, (HashPosition *) 0);
 #endif
 
 
 	for (i = 0; i < 6 ; i++) {
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 		pzval = zend_hash_str_find(HASH_OF(affine_matrix), matrix_elements[i], 2);
 		ZVAL_DEREF(pzval);
 		if (pzval == NULL) {
@@ -1271,7 +1271,7 @@ PHP_METHOD(imagickdraw, affine)
 #endif
 		} else {
 		
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 			value = zval_get_double(pzval);
 #else
 			zval tmp_zval, *tmp_pzval;

--- a/imagickkernel_class.c
+++ b/imagickkernel_class.c
@@ -41,7 +41,7 @@ static void php_imagickkernelvalues_to_zval(zval *zv, KernelInfo *kernel_info) {
 	int count;
 	double value;
 	unsigned int x, y;
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	zval row;
 #else
 	zval *row;
@@ -52,7 +52,7 @@ static void php_imagickkernelvalues_to_zval(zval *zv, KernelInfo *kernel_info) {
 	count = 0;
 
 	for (y=0; y<kernel_info->height ; y++) {
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 		p_row = &row;
 #else
 		MAKE_STD_ZVAL(row);
@@ -88,7 +88,7 @@ HashTable* php_imagickkernel_get_debug_info(zval *obj, int *is_temp TSRMLS_DC) /
 	php_imagickkernel_object *internp;
 	HashTable *debug_info;
 	KernelInfo *kernel_info;
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	zval matrix;
 #else
 	zval *matrix;
@@ -107,7 +107,7 @@ HashTable* php_imagickkernel_get_debug_info(zval *obj, int *is_temp TSRMLS_DC) /
 	ZEND_INIT_SYMTABLE_EX(debug_info, 1, 0);
 
 	while (kernel_info != NULL) {
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 		array_init(&matrix);
 		php_imagickkernelvalues_to_zval(&matrix, kernel_info);
 		zend_hash_next_index_insert(debug_info, &matrix);
@@ -233,7 +233,7 @@ PHP_METHOD(imagickkernel, __construct)
 	matrixes that are odd sizes in both dimensions the the origin pixel will default 
 	to the centre of the kernel. For all other kernel sizes the origin pixel must be specified.
 */
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 PHP_METHOD(imagickkernel, frommatrix)
 {
 	zval *kernel_array;
@@ -404,7 +404,7 @@ cleanup:
 	}
 }
 
-#else //not ZEND_ENGINE_3
+#else // PHP 5
 
 
 PHP_METHOD(imagickkernel, frommatrix)
@@ -735,7 +735,7 @@ PHP_METHOD(imagickkernel, separate)
 	int number_values;
 	KernelValueType * values_copy;
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	zval separate_object;
 #else
 	zval *separate_object;
@@ -764,7 +764,7 @@ PHP_METHOD(imagickkernel, separate)
 			kernel_info->y
 		);
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 		createKernelZval(&separate_object, kernel_info_copy TSRMLS_CC);
 		add_next_index_zval(return_value, &separate_object);
 #else 

--- a/imagickpixeliterator_class.c
+++ b/imagickpixeliterator_class.c
@@ -429,7 +429,7 @@ static
 void s_pixelwands_to_zval (PixelWand **wand_array, unsigned long num_wands, zval *return_value TSRMLS_DC)
 {
 	php_imagickpixel_object *internp;
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	zval obj;
 #else
 	zval *obj;
@@ -440,7 +440,7 @@ void s_pixelwands_to_zval (PixelWand **wand_array, unsigned long num_wands, zval
 	array_init(return_value);
 
 	for (i = 0; i < num_wands; i++) {
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 		object_init_ex(&obj, php_imagickpixel_sc_entry);
 		internp = Z_IMAGICKPIXEL_P(&obj);
 #else 
@@ -452,7 +452,7 @@ void s_pixelwands_to_zval (PixelWand **wand_array, unsigned long num_wands, zval
 		internp->initialized_via_iterator = 1;
 
 		php_imagick_replace_pixelwand(internp, wand_array[i]);
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 		add_next_index_zval(return_value, &obj);
 #else
 		add_next_index_zval(return_value, obj);

--- a/php_imagick_defs.h
+++ b/php_imagick_defs.h
@@ -71,7 +71,7 @@
 #endif
 
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	#define im_long zend_long
 #else
 	#define im_long long
@@ -80,7 +80,7 @@
 
 typedef struct _php_imagick_callback {
 	void ***thread_ctx;
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	zval user_callback;
 #else
 	zval *user_callback;
@@ -143,7 +143,7 @@ ZEND_EXTERN_MODULE_GLOBALS(imagick)
 #endif
 
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 
 /* Structure for Imagick object. */
 typedef struct _php_imagick_object  {
@@ -166,7 +166,7 @@ typedef struct _php_imagick_object  {
 #endif
 
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 
 /* Structure for ImagickDraw object. */
 typedef struct _php_imagickdraw_object  {
@@ -187,7 +187,7 @@ typedef struct _php_imagickdraw_object  {
 
 #endif
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 
 /* Structure for ImagickPixelIterator object. */
 typedef struct _php_imagickpixeliterator_object  {
@@ -221,7 +221,7 @@ typedef struct _php_imagickpixeliterator_object  {
 #endif
 
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 
 /* Structure for ImagickPixel object. */
 typedef struct _php_imagickpixel_object  {
@@ -245,7 +245,7 @@ typedef struct _php_imagickpixel_object  {
 
 
 #ifdef IMAGICK_WITH_KERNEL
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 /* Structure for ImagickKernel object. */
 typedef struct _php_imagickkernel_object  {
 	KernelInfo *kernel_info;
@@ -262,7 +262,7 @@ typedef struct _php_imagickkernel_object  {
 #endif
 
 //Object fetching.
-#ifdef ZEND_ENGINE_3 
+#if PHP_VERSION_ID >= 70000
 
 static inline php_imagick_object *php_imagick_fetch_object(zend_object *obj) {
 	return (php_imagick_object *)((char*)(obj) - XtOffsetOf(php_imagick_object, zo));
@@ -295,7 +295,7 @@ static inline php_imagickkernel_object *php_imagickkernel_fetch_object(zend_obje
 #endif
 
 // Object access
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	#define Z_IMAGICK_P(zv) php_imagick_fetch_object(Z_OBJ_P((zv)))
 	#define Z_IMAGICKDRAW_P(zv) php_imagickdraw_fetch_object(Z_OBJ_P((zv)))
 	#define Z_IMAGICKPIXEL_P(zv) php_imagickpixel_fetch_object(Z_OBJ_P((zv)))
@@ -312,7 +312,7 @@ static inline php_imagickkernel_object *php_imagickkernel_fetch_object(zend_obje
 #endif
 
 // String access
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	#define IM_ZVAL_STRING(zv, charstar) ZVAL_STRING(zv, charstar);
 	#define IM_RETURN_STRING(s) RETURN_STRING(s)
 #else
@@ -321,7 +321,7 @@ static inline php_imagickkernel_object *php_imagickkernel_fetch_object(zend_obje
 	#define IM_RETURN_STRING(s) RETURN_STRING(s, 0)
 #endif
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	#define IM_add_assoc_string(zv, key, charstr) add_assoc_string(zv, key, charstr)
 	#define IM_ZVAL_STRINGL(zv, charstr, length) ZVAL_STRINGL(zv, charstr, length)
 	#define IM_add_next_index_string(zv, charstr) add_next_index_string(zv, charstr)
@@ -335,7 +335,7 @@ static inline php_imagickkernel_object *php_imagickkernel_fetch_object(zend_obje
 	#define IM_LEN_TYPE int
 #endif
 
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 70000
 	#define IM_ZEND_OBJECT zend_object
 #else 
 	#define IM_ZEND_OBJECT void


### PR DESCRIPTION
Because PHP 8 should have ZEND_ENGINE_4, and because the removal of this macro is under discussion

Using PHP_VERSION_ID everywhere seems simpler, especially when you will want to drop support for some old PHP versions