### PR TITLE
Add user location check for ImageMagick 7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,8 @@ services:
       - SYS_PTRACE
     security_opt:
       - seccomp:unconfined
-  ubuntu:
-    build: docker/ubuntu
+  nixos:
+    build: docker/nixos
     volumes:
       - .:/var/app
     cap_add:
@@ -41,4 +41,3 @@ services:
       - SYS_PTRACE
     security_opt:
       - seccomp:unconfined
-

--- a/docker/nixos/Dockerfile
+++ b/docker/nixos/Dockerfile
@@ -1,0 +1,23 @@
+# Start from the latest NixOS unstable.
+FROM nixos/nix
+RUN nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs
+RUN nix-channel --update
+
+# Prepare the build environment.
+COPY shell.nix /opt
+RUN nix-shell /opt/shell.nix --run 'echo OK'
+
+# Keep a symlink to ImageMagick headers.
+RUN nix-build '<nixpkgs>' -A imagemagick7.dev -o /opt/imagemagick
+
+# Prepare the README.
+COPY README.md /opt/
+RUN sed -i \
+  -e "s|@@IM_DEV@@|$(readlink -f /opt/imagemagick-dev)|g" \
+  /opt/README.md
+
+# Make the default directory the mounted source code.
+WORKDIR /var/app
+
+# Run the process that this container will serve.
+CMD tail -f /opt/README.md

--- a/docker/nixos/README.md
+++ b/docker/nixos/README.md
@@ -1,0 +1,8 @@
+The NixOS container is now available. Get a development shell with:
+
+    docker-compose exec nixos nix-shell /opt/shell.nix
+
+You should configure PHP Imagick with:
+
+    phpize
+    ./configure --with-imagick=@@IM_DEV@@

--- a/docker/nixos/shell.nix
+++ b/docker/nixos/shell.nix
@@ -1,0 +1,8 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+with pkgs;
+
+mkShell {
+  nativeBuildInputs = [ php74.unwrapped autoconf pkgconfig re2c ];
+  buildInputs = [ imagemagick7 pcre2 ];
+}

--- a/imagemagick.m4
+++ b/imagemagick.m4
@@ -159,12 +159,20 @@ AC_DEFUN([IM_FIND_IMAGEMAGICK],[
   IM_MAJOR_VERSION=`echo $IM_IMAGEMAGICK_VERSION | $AWK 'BEGIN { FS = "."; } {print $[1]}'`
 
   # Try the header formats from newest to oldest
-  if test -r "${IM_IMAGEMAGICK_PREFIX}/include/ImageMagick-${IM_MAJOR_VERSION}/wand/MagickWand.h"; then
-  
+  if test -r "${IM_IMAGEMAGICK_PREFIX}/include/ImageMagick-${IM_MAJOR_VERSION}/MagickWand/MagickWand.h"; then
+
+    IM_INCLUDE_FORMAT="MagickWand/MagickWand.h"
+    IM_HEADER_STYLE="SEVEN"
+    AC_DEFINE([IM_MAGICKWAND_HEADER_STYLE_SEVEN], [1], [ImageMagick 7.x style header])
+
+    AC_MSG_RESULT([user location ${IM_IMAGEMAGICK_PREFIX}/include/ImageMagick-${IM_MAJOR_VERSION}/MagickWand/MagickWand.h])
+
+  elif test -r "${IM_IMAGEMAGICK_PREFIX}/include/ImageMagick-${IM_MAJOR_VERSION}/wand/MagickWand.h"; then
+
     IM_INCLUDE_FORMAT="wand/MagickWand.h"
     IM_HEADER_STYLE="SIX"
     AC_DEFINE([IM_MAGICKWAND_HEADER_STYLE_SIX], [1], [ImageMagick 6.x style header])
-  
+
     AC_MSG_RESULT([user location ${IM_IMAGEMAGICK_PREFIX}/include/ImageMagick-${IM_MAJOR_VERSION}/wand/MagickWand.h])
 
   elif test -r "${IM_PREFIX}/include/ImageMagick-${IM_MAJOR_VERSION}/MagickWand/MagickWand.h"; then


### PR DESCRIPTION
On NixOS, like other distributions, headers are a separate package, but unique to NixOS is that they won't be in a shared prefix:

```
/nix/store/9s1wq1033kkg0pqrgfq4hyq9sa4n24hb-imagemagick-7.0.10-27
/nix/store/ypz071bmhbjksphfcb72dh712yp5y6vv-imagemagick-7.0.10-27-dev
```

For NixOS, configure is provided the second (`*-dev`) path (var `IM_IMAGEMAGICK_PREFIX`), so it can pick up `MagickWand-config`. In turn, `MagickWand-config --prefix` will return the first path (var `IM_PREFIX`), and `MagickWand-config --cflags` will list an include path from the second. But header detection in `imagemagick.m4` is generally based on `IM_PREFIX`, which won't work on this case.

It appears there was already a 'user location' case in place for ImageMagick 6, based on `IM_IMAGEMAGICK_PREFIX`. I've duplicated this for ImageMagick 7.

Ideally, we'd need a check based on `--cflags`, I think, but I'm not that good at autoconf.