### PR TITLE
Fix fontconfig error in NixOS container

### DIFF
--- a/docker/nixos/shell.nix
+++ b/docker/nixos/shell.nix
@@ -8,4 +8,7 @@ mkShell {
 
   # https://github.com/Imagick/imagick/issues/398
   FONTCONFIG_FILE = "${pkgs.fontconfig.out}/etc/fonts/fonts.conf";
+
+  # https://github.com/Imagick/imagick/issues/399
+  MAGICK_CONFIGURE_PATH = "${imagemagick7.dev}/lib/ImageMagick-7.0.11/config-Q16HDRI";
 }

--- a/docker/nixos/shell.nix
+++ b/docker/nixos/shell.nix
@@ -5,4 +5,7 @@ with pkgs;
 mkShell {
   nativeBuildInputs = [ php74.unwrapped autoconf pkgconfig re2c ];
   buildInputs = [ imagemagick7 pcre2 ];
+
+  # https://github.com/Imagick/imagick/issues/398
+  FONTCONFIG_FILE = "${pkgs.fontconfig.out}/etc/fonts/fonts.conf";
 }


### PR DESCRIPTION
Fixes #398. Fixes #399.

I tested this with the NixOS container:

```sh
docker compose up nixos
docker compose exec nixos nix-shell /opt/shell.nix
phpize
./configure --with-imagick=...
make
php -d extension=imagick.so util/check_fonts.php
```

The last command would before output:

```
Fontconfig error: Cannot load default config file
There are 1 fonts:
  DejaVu-Sans
```

Now it just says:

```
There are 1 fonts:
  DejaVu-Sans
```

This only affects the test setup. The fontconfig stuff is normally prepared by NixOS, but here we are installing standalone Nix packages in Docker, so that's where the difference is coming from.