### PR TITLE
Type issue related to HDRI

### DIFF
--- a/ImagickPixel.stub.php
+++ b/ImagickPixel.stub.php
@@ -20,7 +20,7 @@ class ImagickPixel
     public function getColorQuantum(): array {}
 
     // COLOR_*
-    public function getColorValue(int $color): IMAGICK_QUANTUM_TYPE {}
+    public function getColorValue(int $color): float {}
 
     /**
      * @param int $color // COLOR_*

--- a/ImagickPixel_arginfo.h
+++ b/ImagickPixel_arginfo.h
@@ -67,20 +67,35 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ImagickPixel_getColorQuantum, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 
-#if MAGICKCORE_HDRI_ENABLE 
-
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ImagickPixel_getColorValue, 0, 1, IS_DOUBLE, 0)
 #else
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ImagickPixel_getColorValue, 0, 0, 1)
 #endif
 
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, color, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, color)
+#endif
+ZEND_END_ARG_INFO()
+
+
+#if MAGICKCORE_HDRI_ENABLE 
+
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ImagickPixel_getColorValueQuantum, 0, 1, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ImagickPixel_getColorValueQuantum, 0, 0, 1)
+#endif
+
 #else
 
 #if PHP_VERSION_ID >= 80000
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ImagickPixel_getColorValue, 0, 1, IS_LONG, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_ImagickPixel_getColorValueQuantum, 0, 1, IS_LONG, 0)
 #else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ImagickPixel_getColorValue, 0, 0, 1)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ImagickPixel_getColorValueQuantum, 0, 0, 1)
 #endif
 
 #endif
@@ -92,8 +107,6 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ImagickPixel_getColorValue, 0, 0, 1)
     ZEND_ARG_INFO(0, color)
 #endif
 ZEND_END_ARG_INFO()
-
-#define arginfo_class_ImagickPixel_getColorValueQuantum arginfo_class_ImagickPixel_getColorValue
 
 #define arginfo_class_ImagickPixel_getHSL arginfo_class_ImagickPixel_getColorQuantum
 

--- a/imagickpixel_class.c
+++ b/imagickpixel_class.c
@@ -250,10 +250,17 @@ PHP_METHOD(ImagickPixel, getIndex)
 PHP_METHOD(ImagickPixel, setIndex)
 {
 	php_imagickpixel_object *internp;
+#if MAGICKCORE_HDRI_ENABLE
+	double index;
+
+	/* Parse parameters given to function */
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &index) == FAILURE) {
+#else
 	im_long index;
 
 	/* Parse parameters given to function */
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &index) == FAILURE) {
+#endif
 		return;
 	}
 


### PR DESCRIPTION
# **getColorValue** always return a float 

In pixel-wand.h, bot IM 6 and 7
```
extern WandExport double
  PixelGetAlpha(const PixelWand *) magick_attribute((__pure__)),
  PixelGetBlack(const PixelWand *) magick_attribute((__pure__)),
  PixelGetBlue(const PixelWand *) magick_attribute((__pure__)),
  PixelGetCyan(const PixelWand *) magick_attribute((__pure__)),
  PixelGetFuzz(const PixelWand *) magick_attribute((__pure__)),
  PixelGetGreen(const PixelWand *) magick_attribute((__pure__)),
  PixelGetMagenta(const PixelWand *) magick_attribute((__pure__)),
  PixelGetOpacity(const PixelWand *) magick_attribute((__pure__)),
  PixelGetRed(const PixelWand *) magick_attribute((__pure__)),
  PixelGetYellow(const PixelWand *) magick_attribute((__pure__));
```

Code is OK, arginfo fixed by this PR in 1st commit

# **PixelSetIndex** expects a Quantum arg

Checked in IM 6 and 7  (IndexPacket in 6 is also a Quantun)

In pixel.h

`typedef Quantum IndexPacket;`

And in   pixel-wand.h for IM6

`  PixelSetIndex(PixelWand *,const IndexPacket),`

Or for IM7

`  PixelSetIndex(PixelWand *,const Quantum),`

So arginfo are OK, code fixed by this PR in 2nd commit