### PR TITLE
Improve regen_arginfo.sh to build usable by everyone

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -99,6 +99,7 @@ This extension requires ImageMagick version 6.5.3-10+ and PHP 5.4.0+.
 			<file name="ImagickKernel.stub.php" role="src" />
 			<file name="ImagickPixelIterator.stub.php" role="src" />
 			<file name="php_imagemagick_version_defs.h" role="src" />
+			<file name="regen_arginfo.sh" role="src" />
 			<file name="ChangeLog" role="doc" />
 			<file name="LICENSE" role="doc" />
 			<dir name="examples">
@@ -406,6 +407,7 @@ This extension requires ImageMagick version 6.5.3-10+ and PHP 5.4.0+.
 				<file name="Float32Info.php" role="test" />
 				<file name="FloatInfo.php" role="test" />
 				<file name="functions.php" role="test" />
+				<file name="fixup_arginfo.php" role="src" />
 			</dir>
 		</dir>
 	</contents>

--- a/regen_arginfo.sh
+++ b/regen_arginfo.sh
@@ -1,20 +1,33 @@
+#!/bin/sh
 
-set -e
-set -x
+VER=0$(php-config --vernum 2>/dev/null)
 
-php /usr/local/lib/php/build/gen_stub.php Imagick.stub.php
-php util/fixup_arginfo.php Imagick_arginfo.h
+if [ $VER -lt 70100 ]; then
 
-php /usr/local/lib/php/build/gen_stub.php ImagickDraw.stub.php
-php util/fixup_arginfo.php ImagickDraw_arginfo.h
+	echo "You need php >= 7.1 to run this script"
 
-#php /usr/local/lib/php/build/gen_stub.php ImagickKernel.stub.php
-php /usr/local/lib/php/build/gen_stub.php ImagickKernel.stub.php
-php util/fixup_arginfo.php ImagickKernel_arginfo.h
+elif [ ! -f build/gen_stub.php ]; then
 
-php /usr/local/lib/php/build/gen_stub.php ImagickPixel.stub.php
-php util/fixup_arginfo.php ImagickPixel_arginfo.h
+	echo "You need to run phpize once with PHP 8 to get gen_stub.php script"
 
-php /usr/local/lib/php/build/gen_stub.php ImagickPixelIterator.stub.php
-php util/fixup_arginfo.php ImagickPixelIterator_arginfo.h
+else
 
+	set -e
+	set -x
+
+	php build/gen_stub.php Imagick.stub.php
+	php util/fixup_arginfo.php Imagick_arginfo.h
+
+	php build/gen_stub.php ImagickDraw.stub.php
+	php util/fixup_arginfo.php ImagickDraw_arginfo.h
+
+	php build/gen_stub.php ImagickKernel.stub.php
+	php util/fixup_arginfo.php ImagickKernel_arginfo.h
+
+	php build/gen_stub.php ImagickPixel.stub.php
+	php util/fixup_arginfo.php ImagickPixel_arginfo.h
+
+	php build/gen_stub.php ImagickPixelIterator.stub.php
+	php util/fixup_arginfo.php ImagickPixelIterator_arginfo.h
+
+fi


### PR DESCRIPTION
Current script rely on some /usr/local/bin installation of PHP 8

This one should be usable by everyone, and thus can be distributed with the sources

Notice: this PR also make it executable.