### PR TITLE
cleanup git directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,69 @@
 .libs/
 imagemagick_src/
 php_src/
+
+# Object files
+*.o
+*.lo
+
+# Libraries
+*.lib
+*.a
+*.la
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# archives
+imagick-*.tgz
+
+# autotools
+.deps
+.libs
+config.cache
+config.guess
+config.h
+config.h.in
+config.h.in~
+config.log
+config.nice
+config.status
+config.sub
+configure
+configure.in
+configure.ac
+conftest
+conftest.c
+Makefile
+Makefile.fragments
+Makefile.global
+Makefile.objects
+acinclude.m4
+aclocal.m4
+autom4te.cache
+build
+install-sh
+libtool
+ltmain.sh
+ltmain.sh.backup
+missing
+mkinstalldirs
+modules
+run-tests.php
+run-tests.log
+tmp-php.ini
+
+# Failed Test results
+tests/*.diff
+tests/*.exp
+tests/*.log
+tests/*.php
+tests/*.sh

--- a/tests/031_Imagick_affineTransformImage_basic.phpt
+++ b/tests/031_Imagick_affineTransformImage_basic.phpt
@@ -130,6 +130,11 @@ function affineTransformImage() {
 affineTransformImage() ;
 echo "Ok";
 ?>
+--CLEAN--
+<?php
+$f = __DIR__ . "/test_031.png";
+if (file_exists($f)) unlink($f);
+?>
 --EXPECTF--
 Checking white
 Stats checked

--- a/tests/257_Imagick_setImageChannelMask_basic.phpt
+++ b/tests/257_Imagick_setImageChannelMask_basic.phpt
@@ -14,7 +14,7 @@ $imagick->newPseudoImage(256, 256, "gradient:black-white");
 $initialMask = $imagick->setImageChannelMask(\Imagick::CHANNEL_RED);
 $imagick->brightnessContrastImage(-20, 20);
 $imagick->setImageFormat("png");
-$imagick->writeImage("./maskTest.png");
+$imagick->writeImage(__DIR__ . "/maskTest.png");
 
 $redMask = $imagick->setImageChannelMask(\Imagick::CHANNEL_DEFAULT);
 
@@ -27,6 +27,11 @@ if ($redMask != \Imagick::CHANNEL_RED) {
 }
 
 echo "Ok";
+?>
+--CLEAN--
+<?php
+$f = __DIR__ . '/maskTest.png';
+if (file_exists($f)) unlink($f);
 ?>
 --EXPECTF--
 Ok

--- a/tests/264_ImagickDraw_getTextDirection_basic.phpt
+++ b/tests/264_ImagickDraw_getTextDirection_basic.phpt
@@ -58,9 +58,14 @@ $imagick->drawImage($draw);
 $bytes = $imagick->getImageBlob();
 if (strlen($bytes) <= 0) { echo "Failed to generate image.";}
  
-$imagick->writeImage('./directionTest.png');
+$imagick->writeImage(__DIR__ . '/directionTest.png');
 
 echo "Ok";
+?>
+--CLEAN--
+<?php
+$f = __DIR__ . '/directionTest.png';
+if (file_exists($f)) unlink($f);
 ?>
 --EXPECTF--
 Ok

--- a/tests/274_imagick_setImageAlpha.phpt
+++ b/tests/274_imagick_setImageAlpha.phpt
@@ -17,7 +17,7 @@ $imagick->newPseudoImage(256, 256, 'xc:purple');
 $imagick->setImageAlpha(0.5);
 
 $imagick->setImageFormat('png');
-$imagick->writeImage("./setAlphaTest.png");
+$imagick->writeImage(__DIR__ . "/setAlphaTest.png");
 
 $pixelTypes = array(
 	Imagick::PIXEL_CHAR => array(128, 0, 128, 128),
@@ -70,6 +70,11 @@ foreach ($pixelTypes as $pixelType => $expectedValues) {
 
 echo "Ok";
 
+?>
+--CLEAN--
+<?php
+$f = __DIR__ . '/setAlphaTest.png';
+if (file_exists($f)) unlink($f);
 ?>
 --EXPECTF--
 Ok

--- a/tests/281_imagick_houghLineImage_basic.phpt
+++ b/tests/281_imagick_houghLineImage_basic.phpt
@@ -27,5 +27,10 @@ function houghLineImage() {
 houghLineImage() ;
 echo "Ok";
 ?>
+--CLEAN--
+<?php
+$f = __DIR__ . '/houghline_output_image.png';
+if (file_exists($f)) unlink($f);
+?>
 --EXPECTF--
 Ok


### PR DESCRIPTION
ignore some files generated during the build and not tracked

ensure all tests create their images in tests directory and properly clean it after the run (--no-clean option exists if image needed for manual check)
