### PR TITLE
Fix #81235: Imagick::newPseudoImage => open_basedir restriction

### DIFF
--- a/imagick_file.c
+++ b/imagick_file.c
@@ -44,6 +44,7 @@ zend_bool php_imagick_is_virtual_format(const char *format)
 
 	const char *virtual_fmt[] = {
 		"CAPTION",
+		"CANVAS",
 		"CLIPBOARD",
 		"FRACTAL",
 		"GRADIENT",

--- a/tests/bug81235.phpt
+++ b/tests/bug81235.phpt
@@ -1,0 +1,11 @@
+--TEST--
+Bug #81235 (Imagick::newPseudoImage gives open_basedir restriction error)
+--SKIPIF--
+<?php require_once(__DIR__ . '/skipif.inc'); ?>
+--FILE--
+<?php
+ini_set('open_basedir', __DIR__);
+$imagick = new \Imagick();
+$imagick->newPseudoImage(10, 10, "canvas:white");
+?>
+--EXPECT--


### PR DESCRIPTION
Since `canvas` is a valid pseudo image format, we need to cater to
that.

PS: http://www.imagemagick.org/script/formats.php#pseudo