### PR TITLE
Add most basic CI for building and testing on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,40 @@
+name: Build and Test on Windows
+on: [push]
+jobs:
+  windows:
+    defaults:
+      run:
+        shell: cmd
+    strategy:
+      matrix:
+          version: ["7.4", "8.0"]
+          arch: [x64]
+          ts: [ts]
+    runs-on: windows-latest
+    steps:
+      - name: Checkout imagick
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        id: setup-php
+        uses: cmb69/setup-php-sdk@v0.2
+        with:
+          version: ${{matrix.version}}
+          arch: ${{matrix.arch}}
+          ts: ${{matrix.ts}}
+      - name: Download deps
+        run: |
+          curl -LO https://windows.php.net/downloads/pecl/deps/ImageMagick-7.0.7-11-vc15-${{matrix.arch}}.zip
+          7z x ImageMagick-7.0.7-11-vc15-${{matrix.arch}}.zip -o..\deps
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{matrix.arch}}
+          toolset: ${{steps.setup-php.outputs.toolset}}
+      - name: phpize
+        run: phpize
+      - name: configure
+        run: configure --with-imagick --with-php-build=..\deps --with-prefix=${{steps.setup-php.outputs.prefix}}
+      - name: make
+        run: nmake
+      - name: test
+        run: nmake test TESTS="-j4 --show-diff -g FAIL,BORK,WARN,LEAK tests"


### PR DESCRIPTION
This currently downloads ImageMagick 7.0.7-11, and would need to be updated for newer versions. But in preparation for that, it might be a good idea to cater to the [test failures](https://github.com/cmb69/imagick/runs/4105498256?check_suite_focus=true#step:9:77). 