### PR TITLE
Improve test to not require fopencookie()

### DIFF
--- a/tests/bug59378.phpt
+++ b/tests/bug59378.phpt
@@ -9,7 +9,7 @@ $imagick = new Imagick();
 $imagick->newPseudoImage(640, 480, "LOGO:");
 $imagick->setFormat("png");
 
-$fp = fopen("php://memory", 'r+');
+$fp = fopen("php://temp", 'r+');
 $imagick->writeImageFile($fp);
 rewind($fp);
 $memoryBlob = stream_get_contents($fp);


### PR DESCRIPTION
Casting memory stream to stdio streams requires `fopencookie()` which
is not available on Windows and likely some other systems.  We use a
temporary stream instead.