### PR TITLE
Remove erroneous cast

### DIFF
--- a/imagick_file.c
+++ b/imagick_file.c
@@ -328,7 +328,7 @@ zend_bool php_imagick_stream_handler(php_imagick_object *intern, php_stream *str
 	IMAGICK_SET_ERROR_HANDLING_THROW;
 
 	if (php_stream_can_cast(stream, PHP_STREAM_AS_STDIO | PHP_STREAM_CAST_INTERNAL) == FAILURE ||
-		php_stream_cast(stream, PHP_STREAM_AS_STDIO | PHP_STREAM_CAST_INTERNAL, (void*)&fp, 0) == FAILURE) {
+		php_stream_cast(stream, PHP_STREAM_AS_STDIO | PHP_STREAM_CAST_INTERNAL, &fp, 0) == FAILURE) {
 		IMAGICK_RESTORE_ERROR_HANDLING;
 		return 0;
 	}


### PR DESCRIPTION
The third argument to `php_stream_cast()` is supposed to be a `void**`,
so casting to `void*` is not quite right, and actually superfluous.