### PR TITLE
Fix potential stack corruption

### DIFF
--- a/imagick_class.c
+++ b/imagick_class.c
@@ -5131,7 +5131,7 @@ PHP_METHOD(Imagick, profileImage)
 PHP_METHOD(Imagick, quantizeImage)
 {
 	php_imagick_object *intern;
-	long number_colors, colorspace, tree_depth;
+	im_long number_colors, colorspace, tree_depth;
 	zend_bool dither, measure_error;
 	MagickBooleanType status;
 
@@ -10950,7 +10950,7 @@ PHP_METHOD(Imagick, shadowImage)
 	php_imagick_object *intern;
 	MagickBooleanType status;
 	double opacity, sigma;
-	long x, y;
+	im_long x, y;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ddll", &opacity, &sigma, &x, &y) == FAILURE) {
 		return;

--- a/imagickpixeliterator_class.c
+++ b/imagickpixeliterator_class.c
@@ -398,7 +398,7 @@ PHP_METHOD(ImagickPixelIterator, setIteratorRow)
 {
 	php_imagickpixeliterator_object *internpix;
 	MagickBooleanType status;
-	long row;
+	im_long row;
 
 	/* Parse parameters given to function */
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &row) == FAILURE) {


### PR DESCRIPTION
On architectures where `long` is smaller than `zend_long` (e.g. LLP64),
passing `long*` to `zend_parse_parameters()` as an `l` argument, causes
stack corruption.  I found these cases by running the test suite with a
debug build on Windows.  There might be more such issues, so a manual
code review might be in order.

It also appears to be sensible to check the allowed ranges of the
passed values before passing them to ImageMagick functions to avoid
wrap-around or truncation.