### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Download deps
         run: |
           curl -LO https://windows.php.net/downloads/pecl/deps/ImageMagick-7.1.0-13-1-vc15-${{matrix.arch}}.zip
-          7z x ImageMagick-7.0.7-11-vc15-${{matrix.arch}}.zip -o..\deps
+          7z x ImageMagick-7.1.0-13-1-vc15-${{matrix.arch}}.zip -o..\deps
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1
         with:


### PR DESCRIPTION
We need to use the same version for downloading *and* unpacking.
Introducing a variable would make sense, but the plan is to get that
automated anyway (https://github.com/cmb69/setup-php-sdk/issues/2).

Sorry!