### PR TITLE
Use ImageMagick 7.1.0-18 for Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,8 +23,8 @@ jobs:
           ts: ${{matrix.ts}}
       - name: Download deps
         run: |
-          curl -LO https://windows.php.net/downloads/pecl/deps/ImageMagick-7.1.0-13-1-vc15-${{matrix.arch}}.zip
-          7z x ImageMagick-7.1.0-13-1-vc15-${{matrix.arch}}.zip -o..\deps
+          curl -LO https://windows.php.net/downloads/pecl/deps/ImageMagick-7.1.0-18-vc15-${{matrix.arch}}.zip
+          7z x ImageMagick-7.1.0-18-vc15-${{matrix.arch}}.zip -o..\deps
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1
         with:


### PR DESCRIPTION
[ImageMagick 7.1.0-18 is now available for download](https://windows.php.net/downloads/pecl/deps/), but not yet deployed for PECL builds.