### PR TITLE
Return empty string instead of NULL

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,106 +73,105 @@ jobs:
           for i in `ls tests/*.diff 2>/dev/null`; do echo "-- START ${i}"; cat $i; echo "-- END"; done
           php ./util/check_version.php
 
+  test_all:
+    name: Full PHP ${{ matrix.php }} - I ${{ matrix.imagemagick }}
+    needs: test_basic
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+        php: [5.4, 8.1, 8.0, 7.4, 7.3, 7.2, 7.1, 7.0, 5.6, 5.5]
+        imagemagick: [
+          7.1.0-13,
+          7.0.10-27,
+          7.0.8-4,
+          7.0.1-0,
+          git7,
+          6.9.2-0,
+          6.8.7-0,
+          6.7.8-0,
+          git6
+        ]
+        exclude:
+          - php: 5.4
+            imagemagick: 6.8.7-0
+          - php: 7.4
+            imagemagick: git6
+          - php: 7.3
+            imagemagick: git6
+          - php: 7.2
+            imagemagick: git6
+          - php: 7.1
+            imagemagick: git6
+          - php: 7.0
+            imagemagick: git6
+          - php: 5.6
+            imagemagick: git6
+          - php: 5.5
+            imagemagick: git6
+          - php: 7.4
+            imagemagick: git7
+          - php: 7.3
+            imagemagick: git7
+          - php: 7.2
+            imagemagick: git7
+          - php: 7.1
+            imagemagick: git7
+          - php: 7.0
+            imagemagick: git7
+          - php: 5.6
+            imagemagick: git7
+          - php: 5.5
+            imagemagick: git7
 
-#  test_all:
-#    name: Full PHP ${{ matrix.php }} - I ${{ matrix.imagemagick }}
-#    needs: test_basic
-#    runs-on: ubuntu-20.04
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        os: [ubuntu-20.04]
-#        php: [5.4, 8.1, 8.0, 7.4, 7.3, 7.2, 7.1, 7.0, 5.6, 5.5]
-#        imagemagick: [
-#          7.1.0-13,
-#          7.0.10-27,
-#          7.0.8-4,
-#          7.0.1-0,
-#          git7,
-#          6.9.2-0,
-#          6.8.7-0,
-#          6.7.8-0,
-#          git6
-#        ]
-#        exclude:
-#          - php: 5.4
-#            imagemagick: 6.8.7-0
-#          - php: 7.4
-#            imagemagick: git6
-#          - php: 7.3
-#            imagemagick: git6
-#          - php: 7.2
-#            imagemagick: git6
-#          - php: 7.1
-#            imagemagick: git6
-#          - php: 7.0
-#            imagemagick: git6
-#          - php: 5.6
-#            imagemagick: git6
-#          - php: 5.5
-#            imagemagick: git6
-#          - php: 7.4
-#            imagemagick: git7
-#          - php: 7.3
-#            imagemagick: git7
-#          - php: 7.2
-#            imagemagick: git7
-#          - php: 7.1
-#            imagemagick: git7
-#          - php: 7.0
-#            imagemagick: git7
-#          - php: 5.6
-#            imagemagick: git7
-#          - php: 5.5
-#            imagemagick: git7
-#
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@v2
-#
-#      - name: Setup PHP
-#        uses: shivammathur/setup-php@v2
-#        with:
-#          php-version: ${{ matrix.php }}
-#
-#      - name: Apt install required packages
-#        run: |
-#          sudo apt-get update
-#          sudo apt-get install -y fonts-urw-base35 || true
-#          sudo apt-get install -y libfreetype6-dev || true
-#          sudo apt-get install -y texlive-fonts-recommended || true
-#
-#      - name: Cache ImageMagick
-#        uses: actions/cache@v2
-#        env:
-#          cache-name: cache-ImageMagick
-#        with:
-#          path: ~/im/imagemagick-${{ matrix.imagemagick }}
-#          key: ${{ runner.os }}-ImageMagick-${{ matrix.imagemagick }}
-#
-#      - name: Sanity check package.xml and install ImageMagick
-#        run: |
-#          for file in tests/*.phpt; do grep $(basename $file) package.xml >/dev/null || (echo "Missing $file from package.xml" ; exit 1); done
-#          bash ./imagemagick_dependency.sh "${{ matrix.imagemagick }}" $(pwd)
-#
-#      - name: Configure and check fonts are present
-#        run: |
-#          export NO_INTERACTION=1
-#          export REPORT_EXIT_STATUS=1
-#          export SKIP_SLOW_TESTS=1
-#          export PHP_IMAGICK_VERSION=$(php -r '$sxe = simplexml_load_file ("package.xml"); echo (string) $sxe->version->release;')
-#          export CFLAGS=$(php util/calculate_cflags.php "${{ matrix.php }}" "${{ matrix.imagemagick }}")
-#          echo "CFLAGS are ${CFLAGS}"
-#          phpize
-#          ./configure --with-imagick="${HOME}/im/imagemagick-${{ matrix.imagemagick }}"
-#          sudo make install
-#          php -d extension=imagick.so util/check_fonts.php
-#
-#      - name: Run Imagick tests
-#        run: |
-#          export TEST_PHP_EXECUTABLE=`which php`
-#          php run-tests.php -d extension=imagick.so -d extension_dir=modules -n ./*.phpt --show-diff -g FAIL,BORK,WARN,LEAK
-#          export JOBS=$(php util/calculate_test_jobs.php)
-#          php run-tests.php ${JOBS} -d extension=imagick.so -d extension_dir=modules -n ./tests/*.phpt --show-diff -g FAIL,BORK,WARN,LEAK
-#          for i in `ls tests/*.diff 2>/dev/null`; do echo "-- START ${i}"; cat $i; echo "-- END"; done
-#          php ./util/check_version.php
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Apt install required packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y fonts-urw-base35 || true
+          sudo apt-get install -y libfreetype6-dev || true
+          sudo apt-get install -y texlive-fonts-recommended || true
+
+      - name: Cache ImageMagick
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-ImageMagick
+        with:
+          path: ~/im/imagemagick-${{ matrix.imagemagick }}
+          key: ${{ runner.os }}-ImageMagick-${{ matrix.imagemagick }}
+
+      - name: Sanity check package.xml and install ImageMagick
+        run: |
+          for file in tests/*.phpt; do grep $(basename $file) package.xml >/dev/null || (echo "Missing $file from package.xml" ; exit 1); done
+          bash ./imagemagick_dependency.sh "${{ matrix.imagemagick }}" $(pwd)
+
+      - name: Configure and check fonts are present
+        run: |
+          export NO_INTERACTION=1
+          export REPORT_EXIT_STATUS=1
+          export SKIP_SLOW_TESTS=1
+          export PHP_IMAGICK_VERSION=$(php -r '$sxe = simplexml_load_file ("package.xml"); echo (string) $sxe->version->release;')
+          export CFLAGS=$(php util/calculate_cflags.php "${{ matrix.php }}" "${{ matrix.imagemagick }}")
+          echo "CFLAGS are ${CFLAGS}"
+          phpize
+          ./configure --with-imagick="${HOME}/im/imagemagick-${{ matrix.imagemagick }}"
+          sudo make install
+          php -d extension=imagick.so util/check_fonts.php
+
+      - name: Run Imagick tests
+        run: |
+          export TEST_PHP_EXECUTABLE=`which php`
+          php run-tests.php -d extension=imagick.so -d extension_dir=modules -n ./*.phpt --show-diff -g FAIL,BORK,WARN,LEAK
+          export JOBS=$(php util/calculate_test_jobs.php)
+          php run-tests.php ${JOBS} -d extension=imagick.so -d extension_dir=modules -n ./tests/*.phpt --show-diff -g FAIL,BORK,WARN,LEAK
+          for i in `ls tests/*.diff 2>/dev/null`; do echo "-- START ${i}"; cat $i; echo "-- END"; done
+          php ./util/check_version.php

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,14 +2,12 @@ name: Build and Test on Debian
 
 on:
   push:
-#    branches: [master]
   pull_request:
     types: [opened, synchronize, reopened]
   release:
     types: [created]
 
 jobs:
-
   test_basic:
     name: basic PHP ${{ matrix.php }} - I ${{ matrix.imagemagick }}
     runs-on: ubuntu-20.04
@@ -75,57 +73,120 @@ jobs:
           php ./util/check_version.php
 
 
-  test_all:
-    name: Full PHP ${{ matrix.php }} - I ${{ matrix.imagemagick }}
-    needs: test_basic
+#  test_all:
+#    name: Full PHP ${{ matrix.php }} - I ${{ matrix.imagemagick }}
+#    needs: test_basic
+#    runs-on: ubuntu-20.04
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        os: [ubuntu-20.04]
+#        php: [5.4, 8.1, 8.0, 7.4, 7.3, 7.2, 7.1, 7.0, 5.6, 5.5]
+#        imagemagick: [
+#          7.1.0-13,
+#          7.0.10-27,
+#          7.0.8-4,
+#          7.0.1-0,
+#          git7,
+#          6.9.2-0,
+#          6.8.7-0,
+#          6.7.8-0,
+#          git6
+#        ]
+#        exclude:
+#          - php: 5.4
+#            imagemagick: 6.8.7-0
+#          - php: 7.4
+#            imagemagick: git6
+#          - php: 7.3
+#            imagemagick: git6
+#          - php: 7.2
+#            imagemagick: git6
+#          - php: 7.1
+#            imagemagick: git6
+#          - php: 7.0
+#            imagemagick: git6
+#          - php: 5.6
+#            imagemagick: git6
+#          - php: 5.5
+#            imagemagick: git6
+#          - php: 7.4
+#            imagemagick: git7
+#          - php: 7.3
+#            imagemagick: git7
+#          - php: 7.2
+#            imagemagick: git7
+#          - php: 7.1
+#            imagemagick: git7
+#          - php: 7.0
+#            imagemagick: git7
+#          - php: 5.6
+#            imagemagick: git7
+#          - php: 5.5
+#            imagemagick: git7
+#
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v2
+#
+#      - name: Setup PHP
+#        uses: shivammathur/setup-php@v2
+#        with:
+#          php-version: ${{ matrix.php }}
+#
+#      - name: Apt install required packages
+#        run: |
+#          sudo apt-get update
+#          sudo apt-get install -y fonts-urw-base35 || true
+#          sudo apt-get install -y libfreetype6-dev || true
+#          sudo apt-get install -y texlive-fonts-recommended || true
+#
+#      - name: Cache ImageMagick
+#        uses: actions/cache@v2
+#        env:
+#          cache-name: cache-ImageMagick
+#        with:
+#          path: ~/im/imagemagick-${{ matrix.imagemagick }}
+#          key: ${{ runner.os }}-ImageMagick-${{ matrix.imagemagick }}
+#
+#      - name: Sanity check package.xml and install ImageMagick
+#        run: |
+#          for file in tests/*.phpt; do grep $(basename $file) package.xml >/dev/null || (echo "Missing $file from package.xml" ; exit 1); done
+#          bash ./imagemagick_dependency.sh "${{ matrix.imagemagick }}" $(pwd)
+#
+#      - name: Configure and check fonts are present
+#        run: |
+#          export NO_INTERACTION=1
+#          export REPORT_EXIT_STATUS=1
+#          export SKIP_SLOW_TESTS=1
+#          export PHP_IMAGICK_VERSION=$(php -r '$sxe = simplexml_load_file ("package.xml"); echo (string) $sxe->version->release;')
+#          export CFLAGS=$(php util/calculate_cflags.php "${{ matrix.php }}" "${{ matrix.imagemagick }}")
+#          echo "CFLAGS are ${CFLAGS}"
+#          phpize
+#          ./configure --with-imagick="${HOME}/im/imagemagick-${{ matrix.imagemagick }}"
+#          sudo make install
+#          php -d extension=imagick.so util/check_fonts.php
+#
+#      - name: Run Imagick tests
+#        run: |
+#          export TEST_PHP_EXECUTABLE=`which php`
+#          php run-tests.php -d extension=imagick.so -d extension_dir=modules -n ./*.phpt --show-diff -g FAIL,BORK,WARN,LEAK
+#          export JOBS=$(php util/calculate_test_jobs.php)
+#          php run-tests.php ${JOBS} -d extension=imagick.so -d extension_dir=modules -n ./tests/*.phpt --show-diff -g FAIL,BORK,WARN,LEAK
+#          for i in `ls tests/*.diff 2>/dev/null`; do echo "-- START ${i}"; cat $i; echo "-- END"; done
+#          php ./util/check_version.php
+
+  test_package_is_valid:
+    name: Package is valid
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
-        php: [5.4, 8.1, 8.0, 7.4, 7.3, 7.2, 7.1, 7.0, 5.6, 5.5]
+        os: [ ubuntu-latest ]
+        php: [ 8.0 ]
         imagemagick: [
-          7.1.0-13,
-          7.0.10-27,
-          7.0.8-4,
-          7.0.1-0,
-          git7,
-          6.9.2-0,
-          6.8.7-0,
-          6.7.8-0,
-          git6
+            7.1.0-13
         ]
-        exclude:
-          - php: 5.4
-            imagemagick: 6.8.7-0
-          - php: 7.4
-            imagemagick: git6
-          - php: 7.3
-            imagemagick: git6
-          - php: 7.2
-            imagemagick: git6
-          - php: 7.1
-            imagemagick: git6
-          - php: 7.0
-            imagemagick: git6
-          - php: 5.6
-            imagemagick: git6
-          - php: 5.5
-            imagemagick: git6
-          - php: 7.4
-            imagemagick: git7
-          - php: 7.3
-            imagemagick: git7
-          - php: 7.2
-            imagemagick: git7
-          - php: 7.1
-            imagemagick: git7
-          - php: 7.0
-            imagemagick: git7
-          - php: 5.6
-            imagemagick: git7
-          - php: 5.5
-            imagemagick: git7
 
     steps:
       - name: Checkout code
@@ -142,6 +203,7 @@ jobs:
           sudo apt-get install -y fonts-urw-base35 || true
           sudo apt-get install -y libfreetype6-dev || true
           sudo apt-get install -y texlive-fonts-recommended || true
+          sudo apt-get install -y pkg-php-tools || true
 
       - name: Cache ImageMagick
         uses: actions/cache@v2
@@ -151,30 +213,30 @@ jobs:
           path: ~/im/imagemagick-${{ matrix.imagemagick }}
           key: ${{ runner.os }}-ImageMagick-${{ matrix.imagemagick }}
 
-      - name: Sanity check package.xml and install ImageMagick
+      - name: Build a zip file of the package
         run: |
-          for file in tests/*.phpt; do grep $(basename $file) package.xml >/dev/null || (echo "Missing $file from package.xml" ; exit 1); done
-          bash ./imagemagick_dependency.sh "${{ matrix.imagemagick }}" $(pwd)
+          pear package
+          ls -l
 
-      - name: Configure and check fonts are present
-        run: |
-          export NO_INTERACTION=1
-          export REPORT_EXIT_STATUS=1
-          export SKIP_SLOW_TESTS=1
-          export PHP_IMAGICK_VERSION=$(php -r '$sxe = simplexml_load_file ("package.xml"); echo (string) $sxe->version->release;')
-          export CFLAGS=$(php util/calculate_cflags.php "${{ matrix.php }}" "${{ matrix.imagemagick }}")
-          echo "CFLAGS are ${CFLAGS}"
-          phpize
-          ./configure --with-imagick="${HOME}/im/imagemagick-${{ matrix.imagemagick }}"
-          sudo make install
-          php -d extension=imagick.so util/check_fonts.php
 
-      - name: Run Imagick tests
-        run: |
-          export TEST_PHP_EXECUTABLE=`which php`
-          php run-tests.php -d extension=imagick.so -d extension_dir=modules -n ./*.phpt --show-diff -g FAIL,BORK,WARN,LEAK
-          export JOBS=$(php util/calculate_test_jobs.php)
-          php run-tests.php ${JOBS} -d extension=imagick.so -d extension_dir=modules -n ./tests/*.phpt --show-diff -g FAIL,BORK,WARN,LEAK
-          for i in `ls tests/*.diff 2>/dev/null`; do echo "-- START ${i}"; cat $i; echo "-- END"; done
-          php ./util/check_version.php
-
+#      - name: Configure, install, and basic checks
+#        run: |
+#          export NO_INTERACTION=1
+#          export REPORT_EXIT_STATUS=1
+#          export SKIP_SLOW_TESTS=1
+#          export PHP_IMAGICK_VERSION=$(php -r '$sxe = simplexml_load_file ("package.xml"); echo (string) $sxe->version->release;')
+#          export CFLAGS=$(php util/calculate_cflags.php "${{ matrix.php }}" "${{ matrix.imagemagick }}")
+#          echo "CFLAGS are ${CFLAGS}"
+#          phpize
+#          ./configure --with-imagick="${HOME}/im/imagemagick-${{ matrix.imagemagick }}"
+#          sudo make install
+#          php -d extension=imagick.so util/check_fonts.php
+#
+#      - name: Run Imagick tests
+#        run: |
+#          export TEST_PHP_EXECUTABLE=`which php`
+#          php run-tests.php -d extension=imagick.so -d extension_dir=modules -n ./*.phpt --show-diff -g FAIL,BORK,WARN,LEAK
+#          export JOBS=$(php util/calculate_test_jobs.php)
+#          php run-tests.php ${JOBS} -d extension=imagick.so -d extension_dir=modules -n ./tests/*.phpt --show-diff -g FAIL,BORK,WARN,LEAK
+#          for i in `ls tests/*.diff 2>/dev/null`; do echo "-- START ${i}"; cat $i; echo "-- END"; done
+#          php ./util/check_version.php

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Sanity check package.xml and install ImageMagick
         run: |
+          pear package-validate
           for file in tests/*.phpt; do grep $(basename $file) package.xml >/dev/null || (echo "Missing $file from package.xml" ; exit 1); done
           bash ./imagemagick_dependency.sh "${{ matrix.imagemagick }}" $(pwd)
 
@@ -175,63 +176,3 @@ jobs:
 #          php run-tests.php ${JOBS} -d extension=imagick.so -d extension_dir=modules -n ./tests/*.phpt --show-diff -g FAIL,BORK,WARN,LEAK
 #          for i in `ls tests/*.diff 2>/dev/null`; do echo "-- START ${i}"; cat $i; echo "-- END"; done
 #          php ./util/check_version.php
-
-  test_package_is_valid:
-    name: Package is valid
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-latest ]
-        php: [ 8.0 ]
-        imagemagick: [
-            7.1.0-13
-        ]
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-
-      - name: Apt install required packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y fonts-urw-base35 || true
-          sudo apt-get install -y libfreetype6-dev || true
-          sudo apt-get install -y texlive-fonts-recommended || true
-          sudo apt-get install -y pkg-php-tools || true
-
-      - name: Cache ImageMagick
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-ImageMagick
-        with:
-          path: ~/im/imagemagick-${{ matrix.imagemagick }}
-          key: ${{ runner.os }}-ImageMagick-${{ matrix.imagemagick }}
-
-      - name: Build a zip file of the package
-        run: |
-          # yes "" | pecl install package.xml
-          pecl install package.xml
-          php --ini
-
-      - name: Run basic test
-        run: |
-          export NO_INTERACTION=1
-          export REPORT_EXIT_STATUS=1
-          export SKIP_SLOW_TESTS=1
-          export PHP_IMAGICK_VERSION=$(php -r '$sxe = simplexml_load_file ("package.xml"); echo (string) $sxe->version->release;')
-          php -d extension=imagick.so util/check_fonts.php
-
-      - name: Run Imagick tests
-        run: |
-          export TEST_PHP_EXECUTABLE=`which php`
-          php run-tests.php -d extension=imagick.so -d extension_dir=modules -n ./*.phpt --show-diff -g FAIL,BORK,WARN,LEAK
-          export JOBS=$(php util/calculate_test_jobs.php)
-          php run-tests.php ${JOBS} -d extension=imagick.so -d extension_dir=modules -n ./tests/*.phpt --show-diff -g FAIL,BORK,WARN,LEAK
-          for i in `ls tests/*.diff 2>/dev/null`; do echo "-- START ${i}"; cat $i; echo "-- END"; done
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -215,7 +215,8 @@ jobs:
 
       - name: Build a zip file of the package
         run: |
-          yes "" | pecl install package.xml
+          # yes "" | pecl install package.xml
+          pecl install package.xml
           php --ini
 
       - name: Run basic test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Sanity check package.xml and install ImageMagick
         run: |
-          pear package-validate
+          bash validate_package.sh
           for file in tests/*.phpt; do grep $(basename $file) package.xml >/dev/null || (echo "Missing $file from package.xml" ; exit 1); done
           bash ./imagemagick_dependency.sh "${{ matrix.imagemagick }}" $(pwd)
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,6 @@ jobs:
 
       - name: Sanity check package.xml and install ImageMagick
         run: |
-          bash validate_package.sh
           for file in tests/*.phpt; do grep $(basename $file) package.xml >/dev/null || (echo "Missing $file from package.xml" ; exit 1); done
           bash ./imagemagick_dependency.sh "${{ matrix.imagemagick }}" $(pwd)
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -215,28 +215,22 @@ jobs:
 
       - name: Build a zip file of the package
         run: |
-          pear package
-          ls -l
+          yes "" | pecl install package.xml
+          php --ini
 
+      - name: Run basic test
+        run: |
+          export NO_INTERACTION=1
+          export REPORT_EXIT_STATUS=1
+          export SKIP_SLOW_TESTS=1
+          export PHP_IMAGICK_VERSION=$(php -r '$sxe = simplexml_load_file ("package.xml"); echo (string) $sxe->version->release;')
+          php -d extension=imagick.so util/check_fonts.php
 
-#      - name: Configure, install, and basic checks
-#        run: |
-#          export NO_INTERACTION=1
-#          export REPORT_EXIT_STATUS=1
-#          export SKIP_SLOW_TESTS=1
-#          export PHP_IMAGICK_VERSION=$(php -r '$sxe = simplexml_load_file ("package.xml"); echo (string) $sxe->version->release;')
-#          export CFLAGS=$(php util/calculate_cflags.php "${{ matrix.php }}" "${{ matrix.imagemagick }}")
-#          echo "CFLAGS are ${CFLAGS}"
-#          phpize
-#          ./configure --with-imagick="${HOME}/im/imagemagick-${{ matrix.imagemagick }}"
-#          sudo make install
-#          php -d extension=imagick.so util/check_fonts.php
-#
-#      - name: Run Imagick tests
-#        run: |
-#          export TEST_PHP_EXECUTABLE=`which php`
-#          php run-tests.php -d extension=imagick.so -d extension_dir=modules -n ./*.phpt --show-diff -g FAIL,BORK,WARN,LEAK
-#          export JOBS=$(php util/calculate_test_jobs.php)
-#          php run-tests.php ${JOBS} -d extension=imagick.so -d extension_dir=modules -n ./tests/*.phpt --show-diff -g FAIL,BORK,WARN,LEAK
-#          for i in `ls tests/*.diff 2>/dev/null`; do echo "-- START ${i}"; cat $i; echo "-- END"; done
-#          php ./util/check_version.php
+      - name: Run Imagick tests
+        run: |
+          export TEST_PHP_EXECUTABLE=`which php`
+          php run-tests.php -d extension=imagick.so -d extension_dir=modules -n ./*.phpt --show-diff -g FAIL,BORK,WARN,LEAK
+          export JOBS=$(php util/calculate_test_jobs.php)
+          php run-tests.php ${JOBS} -d extension=imagick.so -d extension_dir=modules -n ./tests/*.phpt --show-diff -g FAIL,BORK,WARN,LEAK
+          for i in `ls tests/*.diff 2>/dev/null`; do echo "-- START ${i}"; cat $i; echo "-- END"; done
+

--- a/.github/workflows/release_validate.yml
+++ b/.github/workflows/release_validate.yml
@@ -1,0 +1,36 @@
+name: Validate pecl package
+
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  release:
+    types: [created]
+
+jobs:
+  test_package_valid:
+    name: basic PHP ${{ matrix.php }}
+    runs-on: ubuntu-20.04
+    if: github.ref == 'refs/heads/master'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest ]
+        php: [ 5.4 ]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Sanity check package.xml and install ImageMagick
+        run: |
+          bash validate_package.sh
+          for file in tests/*.phpt; do grep $(basename $file) package.xml >/dev/null || (echo "Missing $file from package.xml" ; exit 1); done
+
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ tests/*.exp
 tests/*.log
 tests/*.php
 tests/*.sh
+bugReports
+data

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ tests/*.php
 tests/*.sh
 bugReports
 data
+*.dep

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-Unreleased
+3.7.0
 - Added:
   * Imagick::COMPOSITE_SALIENCY_BLEND
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+Unreleased
+- Fixes:
+  * Imagick::clutImage(...) now respects the images interpolate method.
+- Added:
+  * function Imagick::clutImageWithInterpolate(Imagick $lookup_table, int $pixel_interpolate_method): bool  {}
+
 3.7.0
 - Added:
   * Imagick::COMPOSITE_SALIENCY_BLEND

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 Unreleased
 - Fixes:
   * Imagick::clutImage(...) now respects the images interpolate method.
+  * You can now pass null to ImagickDraw::setStrokeDashArray() to reset the dash array.
 - Added:
   * function Imagick::clutImageWithInterpolate(Imagick $lookup_table, int $pixel_interpolate_method): bool  {}
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Unreleased
   * You can now pass null to ImagickDraw::setStrokeDashArray() to reset the dash array.
 - Added:
   * function Imagick::clutImageWithInterpolate(Imagick $lookup_table, int $pixel_interpolate_method): bool  {}
+  * Constants Imagick::COMPRESSION_BC5, Imagick::COMPRESSION_BC7
 
 3.7.0
 - Added:

--- a/Imagick.stub.php
+++ b/Imagick.stub.php
@@ -203,7 +203,7 @@ class Imagick
 
     public function clutImage(Imagick $lookup_table, int $channel = Imagick::CHANNEL_DEFAULT): bool  {}
 
-#if MagickLibVersion > 0x700
+#if MagickLibVersion >= 0x700
     public function clutImageWithInterpolate(
         Imagick $lookup_table,
         int $pixel_interpolate_method // PixelInterpolateMethod
@@ -1253,7 +1253,7 @@ proto bool Imagick::setImageBluePrimary(float x, float y, float z) */
 //    public function key(): int  {}
 //
 //# endif
-//#endif
+#endif
 
     /** @alias Imagick::nextImage
      *  @tentative-return-type

--- a/Imagick.stub.php
+++ b/Imagick.stub.php
@@ -200,8 +200,15 @@ class Imagick
 
 #if MagickLibVersion > 0x635
 
-    // TODO - Imagick
+
     public function clutImage(Imagick $lookup_table, int $channel = Imagick::CHANNEL_DEFAULT): bool  {}
+
+#if MagickLibVersion > 0x700
+    public function clutImageWithInterpolate(
+        Imagick $lookup_table,
+        int $pixel_interpolate_method // PixelInterpolateMethod
+    ): bool  {}
+#endif
 
     public function getImageProperties(string $pattern = "*", bool $include_values = true): array  {}
 

--- a/Imagick.stub.php
+++ b/Imagick.stub.php
@@ -1086,7 +1086,11 @@ class Imagick
     public function setImageBiasQuantum(string $bias): void  {}
 #endif
 
+#if MagickLibVersion >= 0x700
+    public function setImageBluePrimary(float $x, float $y, float $z): bool  {}
+#else
     public function setImageBluePrimary(float $x, float $y): bool  {}
+#endif
     /* {{{ proto bool Imagick::setImageBluePrimary(float x,float y)
 For IM7 the prototype is
 proto bool Imagick::setImageBluePrimary(float x, float y, float z) */
@@ -1103,21 +1107,33 @@ proto bool Imagick::setImageBluePrimary(float x, float y, float z) */
 
     public function setImageExtent(int $columns, int $rows): bool  {}
 
+#if MagickLibVersion >= 0x700
+    public function setImageGreenPrimary(float $x, float $y, float $z): bool  {}
+#else
     public function setImageGreenPrimary(float $x, float $y): bool  {}
+#endif
 
     // INTERLACE_*
     public function setImageInterlaceScheme(int $interlace): bool  {}
 
     public function setImageProfile(string $name, string $profile): bool  {}
 
+#if MagickLibVersion >= 0x700
+    public function setImageRedPrimary(float $x, float $y, float $z): bool  {}
+#else
     public function setImageRedPrimary(float $x, float $y): bool  {}
+#endif
 
     // RENDERINGINTENT
     public function setImageRenderingIntent(int $rendering_intent): bool  {}
 
     public function setImageVirtualPixelMethod(int $method): bool  {}
 
+#if MagickLibVersion >= 0x700
+    public function setImageWhitePoint(float $x, float $y, float $z): bool  {}
+#else
     public function setImageWhitePoint(float $x, float $y): bool  {}
+#endif
 
     public function  sigmoidalContrastImage(
         bool $sharpen,

--- a/ImagickDraw.stub.php
+++ b/ImagickDraw.stub.php
@@ -374,7 +374,7 @@ class ImagickDraw
     public function push(): bool {}
 
     // A typical stroke dash array might contain the members 5 3 2.
-    public function setStrokeDashArray(array $dashes): bool {}
+    public function setStrokeDashArray(array|null $dashes): bool {}
 
 #if MagickLibVersion >= 0x693
     public function getOpacity(): float {}

--- a/ImagickDraw_arginfo.h
+++ b/ImagickDraw_arginfo.h
@@ -1447,7 +1447,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_ImagickDraw_setStrokeDashArray, 0, 0, 1)
 
 	
 #if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, dashes, IS_ARRAY, 0)
+    ZEND_ARG_TYPE_INFO(0, dashes, IS_ARRAY, 1)
 #else
     ZEND_ARG_INFO(0, dashes)
 #endif

--- a/ImagickKernel_arginfo.h
+++ b/ImagickKernel_arginfo.h
@@ -140,27 +140,15 @@ ZEND_METHOD(ImagickKernel, separate);
 #endif
 
 
+#if defined(IMAGICK_WITH_KERNEL)
 static const zend_function_entry class_ImagickKernel_methods[] = {
-#if defined(IMAGICK_WITH_KERNEL)
 	ZEND_ME(ImagickKernel, addKernel, arginfo_class_ImagickKernel_addKernel, ZEND_ACC_PUBLIC)
-#endif
-#if defined(IMAGICK_WITH_KERNEL)
 	ZEND_ME(ImagickKernel, addUnityKernel, arginfo_class_ImagickKernel_addUnityKernel, ZEND_ACC_PUBLIC)
-#endif
-#if defined(IMAGICK_WITH_KERNEL)
 	ZEND_ME(ImagickKernel, fromBuiltin, arginfo_class_ImagickKernel_fromBuiltin, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-#endif
-#if defined(IMAGICK_WITH_KERNEL)
 	ZEND_ME(ImagickKernel, fromMatrix, arginfo_class_ImagickKernel_fromMatrix, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-#endif
-#if defined(IMAGICK_WITH_KERNEL)
 	ZEND_ME(ImagickKernel, getMatrix, arginfo_class_ImagickKernel_getMatrix, ZEND_ACC_PUBLIC)
-#endif
-#if defined(IMAGICK_WITH_KERNEL)
 	ZEND_ME(ImagickKernel, scale, arginfo_class_ImagickKernel_scale, ZEND_ACC_PUBLIC)
-#endif
-#if defined(IMAGICK_WITH_KERNEL)
 	ZEND_ME(ImagickKernel, separate, arginfo_class_ImagickKernel_separate, ZEND_ACC_PUBLIC)
-#endif
 	ZEND_FE_END
 };
+#endif

--- a/Imagick_arginfo.h
+++ b/Imagick_arginfo.h
@@ -1,27 +1,73 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: a1985d42e32acb2cd88c02e8b7dafee699863f4b */
+* Stub hash: regen with 'sh regen_arginfo.sh' 
+* file has been fixedup for different versions */
 
 #if MagickLibVersion > 0x628
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_optimizeImageLayers, 0, 0, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_optimizeImageLayers, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_compareImageLayers, 0, 1, Imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_compareImageLayers, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, metric)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_pingImageBlob, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, image, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_pingImageBlob, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, image, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, image)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_pingImageFile, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, filehandle, IS_MIXED, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filename, IS_STRING, 1, "null")
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_pingImageFile, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, filehandle, IS_MIXED, 0)
+#else
+    ZEND_ARG_INFO(0, filehandle)
+#endif
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filename, IS_STRING, 1, "null")
+#else
+    ZEND_ARG_INFO(0, filename)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
@@ -34,32 +80,106 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_trimImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_trimImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, fuzz)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_waveImage, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, amplitude, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, length, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_waveImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, amplitude, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, amplitude)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, length, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, length)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && MagickLibVersion >= 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_waveImageWithMethod, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, amplitude, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, length, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, interpolate_method, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_waveImageWithMethod, 0, 0, 3)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, amplitude, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, amplitude)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, length, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, length)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, interpolate_method, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, interpolate_method)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_vignetteImage, 0, 4, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, black_point, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, white_point, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_vignetteImage, 0, 0, 4)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, black_point, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, black_point)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, white_point, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, white_point)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, x)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, y)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
@@ -68,66 +188,212 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageMatte, 0, 0, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageMatte, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageMatte, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, matte, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageMatte, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, matte, _IS_BOOL, 0)
+#else
+    ZEND_ARG_INFO(0, matte)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_adaptiveResizeImage, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bestfit, _IS_BOOL, 0, "false")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_adaptiveResizeImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, columns)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, rows)
+#endif
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bestfit, _IS_BOOL, 0, "false")
+#else
+    ZEND_ARG_INFO(0, bestfit)
+#endif
+
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
+#else
+    ZEND_ARG_INFO(0, legacy)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_sketchImage, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_sketchImage, 0, 0, 3)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, radius)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, sigma)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, angle)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_shadeImage, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, gray, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, azimuth, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, elevation, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_shadeImage, 0, 0, 3)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, gray, _IS_BOOL, 0)
+#else
+    ZEND_ARG_INFO(0, gray)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, azimuth, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, azimuth)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, elevation, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, elevation)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getSizeOffset, 0, 0, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getSizeOffset, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setSizeOffset, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setSizeOffset, 0, 0, 3)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, columns)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, rows)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, offset)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_adaptiveBlurImage, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_adaptiveBlurImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, radius)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, sigma)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_contrastStretchImage, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, black_point, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, white_point, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_contrastStretchImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, black_point, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, black_point)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, white_point, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, white_point)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
@@ -137,19 +403,63 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_randomThresholdImage, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, low, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, high, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_randomThresholdImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, low, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, low)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, high, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, high)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_roundCornersImage, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, x_rounding, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, y_rounding, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, stroke_width, IS_DOUBLE, 0, "10")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, displace, IS_DOUBLE, 0, "5")
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_roundCornersImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x_rounding, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, x_rounding)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y_rounding, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, y_rounding)
+#endif
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, stroke_width, IS_DOUBLE, 0, "10")
+#else
+    ZEND_ARG_INFO(0, stroke_width)
+#endif
+
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, displace, IS_DOUBLE, 0, "5")
+#else
+    ZEND_ARG_INFO(0, displace)
+#endif
+
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, size_correction, IS_DOUBLE, 0, "-6")
 ZEND_END_ARG_INFO()
 #endif
@@ -159,8 +469,19 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setIteratorIndex, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setIteratorIndex, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, index)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
@@ -169,87 +490,250 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && MagickLibVersion < 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_transformImage, 0, 2, Imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, crop, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, geometry, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_transformImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, crop, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, crop)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, geometry, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, geometry)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x630 && MagickLibVersion < 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageOpacity, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, opacity, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageOpacity, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, opacity, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, opacity)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x630 && MagickLibVersion >= 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageAlpha, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, alpha, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageAlpha, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, alpha, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, alpha)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x630 && MagickLibVersion < 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_orderedPosterizeImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, threshold_map, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_orderedPosterizeImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, threshold_map, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, threshold_map)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion >= 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_polaroidWithTextAndMethod, 0, 4, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_polaroidWithTextAndMethod, 0, 0, 4)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, settings, ImagickDraw, 0)
-	ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, caption, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, method, IS_LONG, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, angle)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, caption, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, caption)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, method, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, method)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x631
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_polaroidImage, 0, 2, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_polaroidImage, 0, 0, 2)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, settings, ImagickDraw, 0)
-	ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, angle)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x631
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageProperty, 0, 1, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageProperty, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, name)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x631
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageProperty, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageProperty, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, name)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, value)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x631
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_deleteImageProperty, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_deleteImageProperty, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, name)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x631
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_identifyFormat, 0, 1, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, format, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_identifyFormat, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, format, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, format)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x631 && IM_HAVE_IMAGICK_SETIMAGEINTERPOLATEMETHOD
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageInterpolateMethod, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, method, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageInterpolateMethod, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, method, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, method)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x631
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageInterpolateMethod, 0, 0, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageInterpolateMethod, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x631
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_linearStretchImage, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, black_point, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, white_point, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_linearStretchImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, black_point, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, black_point)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, white_point, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, white_point)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
@@ -258,54 +742,147 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x631
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_extentImage, 0, 4, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_extentImage, 0, 0, 4)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, width)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, height)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, x)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, y)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x633
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageOrientation, 0, 0, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageOrientation, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x633
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageOrientation, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, orientation, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageOrientation, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, orientation, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, orientation)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion > 0x634 && MagickLibVersion < 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_paintFloodfillImage, 0, 5, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_paintFloodfillImage, 0, 0, 5)
+#endif
+
 	ZEND_ARG_OBJ_TYPE_MASK(0, fill_color, ImagickPixel, MAY_BE_STRING, NULL)
-	ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, fuzz)
+#endif
 	ZEND_ARG_OBJ_TYPE_MASK(0, border_color, ImagickPixel, MAY_BE_STRING, NULL)
-	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, x)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, y)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x635
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_clutImage, 0, 1, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_clutImage, 0, 0, 1)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, lookup_table, Imagick, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x635 && MagickLibVersion > 0x700
+#if MagickLibVersion > 0x635 && MagickLibVersion >= 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_clutImageWithInterpolate, 0, 2, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_clutImageWithInterpolate, 0, 0, 2)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, lookup_table, Imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, pixel_interpolate_method, IS_LONG, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, pixel_interpolate_method, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, pixel_interpolate_method)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x635
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageProperties, 0, 0, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageProperties, 0, 0, 0)
+#endif
+
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, pattern, IS_STRING, 0, "\"*\"")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, include_values, _IS_BOOL, 0, "true")
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, include_values, _IS_BOOL, 0, "true")
+#else
+    ZEND_ARG_INFO(0, include_values)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
@@ -314,17 +891,55 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x635
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_distortImage, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, distortion, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, arguments, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO(0, bestfit, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_distortImage, 0, 0, 3)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, distortion, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, distortion)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, arguments, IS_ARRAY, 0)
+#else
+    ZEND_ARG_INFO(0, arguments)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, bestfit, _IS_BOOL, 0)
+#else
+    ZEND_ARG_INFO(0, bestfit)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x635
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_writeImageFile, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, filehandle, IS_MIXED, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, format, IS_STRING, 1, "null")
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_writeImageFile, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, filehandle, IS_MIXED, 0)
+#else
+    ZEND_ARG_INFO(0, filehandle)
+#endif
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, format, IS_STRING, 1, "null")
+#else
+    ZEND_ARG_INFO(0, format)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
@@ -333,111 +948,312 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x635
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_resetImagePage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, page, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_resetImagePage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, page, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, page)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x635 && MagickLibVersion < 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageClipMask, 0, 1, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageClipMask, 0, 0, 1)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, clip_mask, imagick, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x635 && MagickLibVersion < 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getImageClipMask, 0, 0, Imagick, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageClipMask, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x635
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_animateImages, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, x_server, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_animateImages, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x_server, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, x_server)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x635 && !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_recolorImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, matrix, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_recolorImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, matrix, IS_ARRAY, 0)
+#else
+    ZEND_ARG_INFO(0, matrix)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x636
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setFont, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, font, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setFont, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, font, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, font)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x636
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getFont, 0, 0, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getFont, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x636
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setPointSize, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, point_size, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setPointSize, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, point_size, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, point_size)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x636
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getPointSize, 0, 0, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getPointSize, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x636
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_mergeImageLayers, 0, 1, Imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, layermethod, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_mergeImageLayers, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, layermethod, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, layermethod)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x637
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageAlphaChannel, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, alphachannel, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageAlphaChannel, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, alphachannel, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, alphachannel)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x637
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_floodfillPaintImage, 0, 6, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_floodfillPaintImage, 0, 0, 6)
+#endif
+
 	ZEND_ARG_OBJ_TYPE_MASK(0, fill_color, ImagickPixel, MAY_BE_STRING, NULL)
-	ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, fuzz)
+#endif
 	ZEND_ARG_OBJ_TYPE_MASK(0, border_color, ImagickPixel, MAY_BE_STRING, NULL)
-	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, invert, _IS_BOOL, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, x)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, y)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, invert, _IS_BOOL, 0)
+#else
+    ZEND_ARG_INFO(0, invert)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 1, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x637
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_opaquePaintImage, 0, 4, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_opaquePaintImage, 0, 0, 4)
+#endif
+
 	ZEND_ARG_OBJ_TYPE_MASK(0, target_color, ImagickPixel, MAY_BE_STRING, NULL)
 	ZEND_ARG_OBJ_TYPE_MASK(0, fill_color, ImagickPixel, MAY_BE_STRING, NULL)
-	ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, invert, _IS_BOOL, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, fuzz)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, invert, _IS_BOOL, 0)
+#else
+    ZEND_ARG_INFO(0, invert)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x637
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_transparentPaintImage, 0, 4, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_transparentPaintImage, 0, 0, 4)
+#endif
+
 	ZEND_ARG_OBJ_TYPE_MASK(0, target_color, ImagickPixel, MAY_BE_STRING, NULL)
-	ZEND_ARG_TYPE_INFO(0, alpha, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, invert, _IS_BOOL, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, alpha, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, alpha)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, fuzz)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, invert, _IS_BOOL, 0)
+#else
+    ZEND_ARG_INFO(0, invert)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x638
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_liquidRescaleImage, 0, 4, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, delta_x, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, rigidity, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_liquidRescaleImage, 0, 0, 4)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, width)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, height)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, delta_x, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, delta_x)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, rigidity, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, rigidity)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x638
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_encipherImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, passphrase, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_encipherImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, passphrase, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, passphrase)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
@@ -446,268 +1262,861 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x639
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setGravity, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, gravity, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setGravity, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, gravity, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, gravity)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x639
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getGravity, 0, 0, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getGravity, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x639
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageChannelRange, 0, 1, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageChannelRange, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, channel)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x639
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageAlphaChannel, 0, 0, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageAlphaChannel, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x642
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageChannelDistortions, 0, 2, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageChannelDistortions, 0, 0, 2)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, reference_image, Imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, metric)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x643
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageGravity, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, gravity, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageGravity, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, gravity, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, gravity)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x643
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageGravity, 0, 0, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageGravity, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x645
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_importImagePixels, 0, 7, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, map, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, pixelstorage, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, pixels, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_importImagePixels, 0, 0, 7)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, x)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, y)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, width)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, height)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, map, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, map)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, pixelstorage, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, pixelstorage)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, pixels, IS_ARRAY, 0)
+#else
+    ZEND_ARG_INFO(0, pixels)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x645
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_deskewImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_deskewImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, threshold)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x645
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_segmentImage, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, cluster_threshold, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, smooth_threshold, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, verbose, _IS_BOOL, 0, "false")
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_segmentImage, 0, 0, 3)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, colorspace)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, cluster_threshold, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, cluster_threshold)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, smooth_threshold, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, smooth_threshold)
+#endif
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, verbose, _IS_BOOL, 0, "false")
+#else
+    ZEND_ARG_INFO(0, verbose)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x645
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_sparseColorImage, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, sparsecolormethod, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, arguments, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_sparseColorImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, sparsecolormethod, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, sparsecolormethod)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, arguments, IS_ARRAY, 0)
+#else
+    ZEND_ARG_INFO(0, arguments)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x645
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_remapImage, 0, 2, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_remapImage, 0, 0, 2)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, replacement, Imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, dither_method, IS_LONG, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, dither_method, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, dither_method)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if PHP_IMAGICK_HAVE_HOUGHLINE
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_houghLineImage, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_houghLineImage, 0, 0, 3)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, width)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, height)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, threshold)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x646
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_exportImagePixels, 0, 6, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, map, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, pixelstorage, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_exportImagePixels, 0, 0, 6)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, x)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, y)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, width)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, height)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, map, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, map)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, pixelstorage, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, pixelstorage)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x648
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageChannelKurtosis, 0, 0, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageChannelKurtosis, 0, 0, 0)
+#endif
+
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x648
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_functionImage, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, function, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, parameters, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_functionImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, function, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, function)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, parameters, IS_ARRAY, 0)
+#else
+    ZEND_ARG_INFO(0, parameters)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x651
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_transformImageColorspace, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_transformImageColorspace, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, colorspace)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x652
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_haldClutImage, 0, 1, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_haldClutImage, 0, 0, 1)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, clut, Imagick, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x655
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_autoLevelImage, 0, 0, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_autoLevelImage, 0, 0, 0)
+#endif
+
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x655
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_blueShiftImage, 0, 0, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_blueShiftImage, 0, 0, 0)
+#endif
+
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, factor, IS_DOUBLE, 0, "1.5")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x656
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageArtifact, 0, 1, IS_STRING, 1)
-	ZEND_ARG_TYPE_INFO(0, artifact, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageArtifact, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, artifact, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, artifact)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x656
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageArtifact, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, artifact, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 1)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageArtifact, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, artifact, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, artifact)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 1)
+#else
+    ZEND_ARG_INFO(0, value)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x656
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_deleteImageArtifact, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, artifact, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_deleteImageArtifact, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, artifact, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, artifact)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x656
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getColorspace, 0, 0, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getColorspace, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x656
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setColorspace, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setColorspace, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, colorspace)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x656
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_clampImage, 0, 0, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_clampImage, 0, 0, 0)
+#endif
+
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x667
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_smushImages, 0, 2, Imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, stack, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_smushImages, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, stack, _IS_BOOL, 0)
+#else
+    ZEND_ARG_INFO(0, stack)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, offset)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick___construct, 0, 0, 0)
-	ZEND_ARG_TYPE_MASK(0, files, MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_LONG|MAY_BE_DOUBLE|MAY_BE_NULL, "null")
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_MASK(0, files, MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_LONG|MAY_BE_DOUBLE|MAY_BE_NULL, "null")
+#else
+    ZEND_ARG_INFO(0, files)
+#endif
+
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick___toString, 0, 0, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick___toString, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 
 #if PHP_VERSION_ID >= 50600
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_count, 0, 0, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "0")
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_count, 0, 0, 0)
+#endif
+
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "0")
+#else
+    ZEND_ARG_INFO(0, mode)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
 #if !(PHP_VERSION_ID >= 50600)
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_count, 0, 0, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_count, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getPixelIterator, 0, 0, ImagickPixelIterator, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getPixelIterator, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getPixelRegionIterator, 0, 4, ImagickPixelIterator, 0)
-	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getPixelRegionIterator, 0, 0, 4)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, x)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, y)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, columns)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, rows)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_readImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_readImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, filename)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_readImages, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, filenames, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_readImages, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, filenames, IS_ARRAY, 0)
+#else
+    ZEND_ARG_INFO(0, filenames)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_readImageBlob, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, image, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filename, IS_STRING, 1, "null")
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_readImageBlob, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, image, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, image)
+#endif
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filename, IS_STRING, 1, "null")
+#else
+    ZEND_ARG_INFO(0, filename)
+#endif
+
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageFormat, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, format, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageFormat, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, format, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, format)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_scaleImage, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bestfit, _IS_BOOL, 0, "false")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_scaleImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, columns)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, rows)
+#endif
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bestfit, _IS_BOOL, 0, "false")
+#else
+    ZEND_ARG_INFO(0, bestfit)
+#endif
+
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
+#else
+    ZEND_ARG_INFO(0, legacy)
+#endif
+
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_writeImage, 0, 0, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filename, IS_STRING, 1, "null")
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_writeImage, 0, 0, 0)
+#endif
+
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filename, IS_STRING, 1, "null")
+#else
+    ZEND_ARG_INFO(0, filename)
+#endif
+
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_writeImages, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, adjoin, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_writeImages, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, filename)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, adjoin, _IS_BOOL, 0)
+#else
+    ZEND_ARG_INFO(0, adjoin)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_blurImage, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_blurImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, radius)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, sigma)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_thumbnailImage, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 1)
-	ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 1)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bestfit, _IS_BOOL, 0, "false")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, fill, _IS_BOOL, 0, "false")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_thumbnailImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 1)
+#else
+    ZEND_ARG_INFO(0, columns)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 1)
+#else
+    ZEND_ARG_INFO(0, rows)
+#endif
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bestfit, _IS_BOOL, 0, "false")
+#else
+    ZEND_ARG_INFO(0, bestfit)
+#endif
+
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, fill, _IS_BOOL, 0, "false")
+#else
+    ZEND_ARG_INFO(0, fill)
+#endif
+
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
+#else
+    ZEND_ARG_INFO(0, legacy)
+#endif
+
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_cropThumbnailImage, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_cropThumbnailImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, width)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, height)
+#endif
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
+#else
+    ZEND_ARG_INFO(0, legacy)
+#endif
+
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageFilename arginfo_class_Imagick___toString
@@ -718,17 +2127,35 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageMimeType arginfo_class_Imagick___toString
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_removeImage, 0, 0, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_removeImage, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_destroy arginfo_class_Imagick_removeImage
 
 #define arginfo_class_Imagick_clear arginfo_class_Imagick_removeImage
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_clone, 0, 0, Imagick, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_clone, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageSize, 0, 0, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageSize, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageBlob arginfo_class_Imagick___toString
@@ -739,7 +2166,13 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_setLastIterator arginfo_class_Imagick_removeImage
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_resetIterator, 0, 0, IS_VOID, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_resetIterator, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_previousImage arginfo_class_Imagick_removeImage
@@ -750,224 +2183,817 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_hasNextImage arginfo_class_Imagick_removeImage
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageIndex, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageIndex, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, index)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageIndex arginfo_class_Imagick_getImageSize
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_commentImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, comment, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_commentImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, comment, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, comment)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_cropImage, 0, 4, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_cropImage, 0, 0, 4)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, width)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, height)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, x)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, y)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_labelImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, label, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_labelImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, label, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, label)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageGeometry, 0, 0, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageGeometry, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_drawImage, 0, 1, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_drawImage, 0, 0, 1)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, drawing, ImagickDraw, 0)
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageCompressionQuality, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, quality, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageCompressionQuality, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, quality, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, quality)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageCompressionQuality arginfo_class_Imagick_getImageSize
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageCompression, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, compression, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageCompression, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, compression, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, compression)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageCompression arginfo_class_Imagick_getImageSize
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_annotateImage, 0, 5, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_annotateImage, 0, 0, 5)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, settings, ImagickDraw, 0)
-	ZEND_ARG_TYPE_INFO(0, x, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, y, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, text, IS_STRING, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, x)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, y)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, angle)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, text, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, text)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_compositeImage, 0, 4, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_compositeImage, 0, 0, 4)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, composite_image, Imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, composite, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, composite, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, composite)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, x)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, y)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_modulateImage, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, brightness, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, saturation, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, hue, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_modulateImage, 0, 0, 3)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, brightness, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, brightness)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, saturation, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, saturation)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, hue, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, hue)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageColors arginfo_class_Imagick_getImageSize
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_montageImage, 0, 5, Imagick, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_montageImage, 0, 0, 5)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, settings, ImagickDraw, 0)
-	ZEND_ARG_TYPE_INFO(0, tile_geometry, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, thumbnail_geometry, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, monatgemode, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, frame, IS_STRING, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, tile_geometry, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, tile_geometry)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, thumbnail_geometry, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, thumbnail_geometry)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, monatgemode, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, monatgemode)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, frame, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, frame)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_identifyImage, 0, 0, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, append_raw_output, _IS_BOOL, 0, "false")
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_identifyImage, 0, 0, 0)
+#endif
+
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, append_raw_output, _IS_BOOL, 0, "false")
+#else
+    ZEND_ARG_INFO(0, append_raw_output)
+#endif
+
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_thresholdImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_thresholdImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, threshold)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_adaptiveThresholdImage, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_adaptiveThresholdImage, 0, 0, 3)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, width)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, height)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, offset)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_blackThresholdImage, 0, 1, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_blackThresholdImage, 0, 0, 1)
+#endif
+
 	ZEND_ARG_OBJ_TYPE_MASK(0, threshold_color, ImagickPixel, MAY_BE_STRING, NULL)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_whiteThresholdImage arginfo_class_Imagick_blackThresholdImage
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_appendImages, 0, 1, Imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, stack, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_appendImages, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, stack, _IS_BOOL, 0)
+#else
+    ZEND_ARG_INFO(0, stack)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_charcoalImage, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_charcoalImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, radius)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, sigma)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_normalizeImage, 0, 0, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_normalizeImage, 0, 0, 0)
+#endif
+
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
 #if MagickLibVersion >= 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_oilPaintImageWithSigma, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_oilPaintImageWithSigma, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, radius)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, sigma)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_oilPaintImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_oilPaintImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, radius)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_posterizeImage, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, levels, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, dither, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_posterizeImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, levels, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, levels)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, dither, _IS_BOOL, 0)
+#else
+    ZEND_ARG_INFO(0, dither)
+#endif
 ZEND_END_ARG_INFO()
 
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_radialBlurImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_radialBlurImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, angle)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_raiseImage, 0, 5, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, raise, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_raiseImage, 0, 0, 5)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, width)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, height)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, x)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, y)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, raise, _IS_BOOL, 0)
+#else
+    ZEND_ARG_INFO(0, raise)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_resampleImage, 0, 4, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, x_resolution, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, y_resolution, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, filter, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, blur, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_resampleImage, 0, 0, 4)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x_resolution, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, x_resolution)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y_resolution, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, y_resolution)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, filter, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, filter)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, blur, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, blur)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_resizeImage, 0, 4, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, filter, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, blur, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bestfit, _IS_BOOL, 0, "false")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_resizeImage, 0, 0, 4)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, columns)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, rows)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, filter, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, filter)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, blur, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, blur)
+#endif
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bestfit, _IS_BOOL, 0, "false")
+#else
+    ZEND_ARG_INFO(0, bestfit)
+#endif
+
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
+#else
+    ZEND_ARG_INFO(0, legacy)
+#endif
+
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_rollImage, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_rollImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, x)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, y)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_rotateImage, 0, 2, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_rotateImage, 0, 0, 2)
+#endif
+
 	ZEND_ARG_OBJ_TYPE_MASK(0, background_color, ImagickPixel, MAY_BE_STRING, NULL)
-	ZEND_ARG_TYPE_INFO(0, degrees, IS_DOUBLE, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, degrees, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, degrees)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_sampleImage, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_sampleImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, columns)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, rows)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_solarizeImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, threshold, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_solarizeImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, threshold, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, threshold)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_shadowImage, 0, 4, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, opacity, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_shadowImage, 0, 0, 4)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, opacity, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, opacity)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, sigma)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, x)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, y)
+#endif
 ZEND_END_ARG_INFO()
 
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageAttribute, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageAttribute, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, key)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, value)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageBackgroundColor, 0, 1, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageBackgroundColor, 0, 0, 1)
+#endif
+
 	ZEND_ARG_OBJ_TYPE_MASK(0, background_color, ImagickPixel, MAY_BE_STRING, NULL)
 ZEND_END_ARG_INFO()
 
 #if MagickLibVersion >= 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageChannelMask, 0, 1, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageChannelMask, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, channel)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageCompose, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, compose, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageCompose, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, compose, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, compose)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageDelay, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, delay, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageDelay, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, delay, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, delay)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageDepth, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, depth, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageDepth, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, depth, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, depth)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageGamma, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, gamma, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageGamma, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, gamma, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, gamma)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageIterations, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, iterations, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageIterations, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, iterations, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, iterations)
+#endif
 ZEND_END_ARG_INFO()
 
 #if MagickLibVersion < 0x700 || MagickLibVersion >= 0x705
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageMatteColor, 0, 1, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageMatteColor, 0, 0, 1)
+#endif
+
 	ZEND_ARG_OBJ_TYPE_MASK(0, matte_color, ImagickPixel, MAY_BE_STRING, NULL)
 ZEND_END_ARG_INFO()
 #endif
@@ -977,53 +3003,168 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_Imagick_setImageProgressMonitor arginfo_class_Imagick_readImage
 
 #if MagickLibVersion > 0x653
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setProgressMonitor, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setProgressMonitor, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
+#else
+    ZEND_ARG_INFO(0, callback)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageResolution, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, x_resolution, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, y_resolution, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageResolution, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x_resolution, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, x_resolution)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y_resolution, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, y_resolution)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageScene, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, scene, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageScene, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, scene, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, scene)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageTicksPerSecond, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, ticks_per_second, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageTicksPerSecond, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, ticks_per_second, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, ticks_per_second)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageType, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, image_type, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageType, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, image_type, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, image_type)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageUnits, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, units, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageUnits, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, units, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, units)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_sharpenImage arginfo_class_Imagick_blurImage
 
 #define arginfo_class_Imagick_shaveImage arginfo_class_Imagick_sampleImage
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_shearImage, 0, 3, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_shearImage, 0, 0, 3)
+#endif
+
 	ZEND_ARG_OBJ_TYPE_MASK(0, background_color, ImagickPixel, MAY_BE_STRING, NULL)
-	ZEND_ARG_TYPE_INFO(0, x_shear, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, y_shear, IS_DOUBLE, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x_shear, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, x_shear)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y_shear, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, y_shear)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_spliceImage arginfo_class_Imagick_cropImage
 
 #define arginfo_class_Imagick_pingImage arginfo_class_Imagick_readImage
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_readImageFile, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, filehandle, IS_MIXED, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filename, IS_STRING, 1, "null")
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_readImageFile, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, filehandle, IS_MIXED, 0)
+#else
+    ZEND_ARG_INFO(0, filehandle)
+#endif
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filename, IS_STRING, 1, "null")
+#else
+    ZEND_ARG_INFO(0, filename)
+#endif
+
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_displayImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, servername, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_displayImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, servername, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, servername)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_displayImages arginfo_class_Imagick_displayImage
@@ -1031,160 +3172,513 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_Imagick_spreadImage arginfo_class_Imagick_oilPaintImage
 
 #if MagickLibVersion >= 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_spreadImageWithMethod, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, interpolate_method, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_spreadImageWithMethod, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, radius)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, interpolate_method, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, interpolate_method)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_swirlImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, degrees, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_swirlImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, degrees, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, degrees)
+#endif
 ZEND_END_ARG_INFO()
 
 #if MagickLibVersion >= 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_swirlImageWithMethod, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, degrees, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, interpolate_method, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_swirlImageWithMethod, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, degrees, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, degrees)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, interpolate_method, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, interpolate_method)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #define arginfo_class_Imagick_stripImage arginfo_class_Imagick_removeImage
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_queryFormats, 0, 0, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_queryFormats, 0, 0, 0)
+#endif
+
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, pattern, IS_STRING, 0, "\"*\"")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_queryFonts arginfo_class_Imagick_queryFormats
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_queryFontMetrics, 0, 2, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_queryFontMetrics, 0, 0, 2)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, settings, ImagickDraw, 0)
-	ZEND_ARG_TYPE_INFO(0, text, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, multiline, _IS_BOOL, 1, "null")
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, text, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, text)
+#endif
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, multiline, _IS_BOOL, 1, "null")
+#else
+    ZEND_ARG_INFO(0, multiline)
+#endif
+
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_steganoImage, 0, 2, Imagick, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_steganoImage, 0, 0, 2)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, watermark, Imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, offset)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_addNoiseImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, noise, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_addNoiseImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, noise, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, noise)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
 #if IM_HAVE_IMAGICK_ADD_NOISE_WITH_ATTENUATE
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_addNoiseImageWithAttenuate, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, noise, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, attenuate, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_addNoiseImageWithAttenuate, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, noise, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, noise)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, attenuate, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, attenuate)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_motionBlurImage, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_motionBlurImage, 0, 0, 3)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, radius)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, sigma)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, angle)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
 #if MagickLibVersion < 0x700 && !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_mosaicImages, 0, 0, Imagick, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_mosaicImages, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_morphImages, 0, 1, Imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, number_frames, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_morphImages, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, number_frames, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, number_frames)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_minifyImage arginfo_class_Imagick_removeImage
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_affineTransformImage, 0, 1, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_affineTransformImage, 0, 0, 1)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, settings, ImagickDraw, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_averageImages arginfo_class_Imagick_clone
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_borderImage, 0, 3, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_borderImage, 0, 0, 3)
+#endif
+
 	ZEND_ARG_OBJ_TYPE_MASK(0, border_color, ImagickPixel, MAY_BE_STRING, NULL)
-	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, width)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, height)
+#endif
 ZEND_END_ARG_INFO()
 
 #if MagickLibVersion >= 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_borderImageWithComposite, 0, 4, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_borderImageWithComposite, 0, 0, 4)
+#endif
+
 	ZEND_ARG_OBJ_TYPE_MASK(0, border_color, ImagickPixel, MAY_BE_STRING, NULL)
-	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, composite, IS_LONG, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, width)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, height)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, composite, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, composite)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_calculateCrop, 0, 4, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO(0, original_width, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, original_height, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, desired_width, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, desired_height, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_calculateCrop, 0, 0, 4)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, original_width, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, original_width)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, original_height, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, original_height)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, desired_width, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, desired_width)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, desired_height, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, desired_height)
+#endif
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
+#else
+    ZEND_ARG_INFO(0, legacy)
+#endif
+
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_chopImage arginfo_class_Imagick_cropImage
 
 #define arginfo_class_Imagick_clipImage arginfo_class_Imagick_removeImage
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_clipPathImage, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, pathname, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, inside, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_clipPathImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, pathname, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, pathname)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, inside, _IS_BOOL, 0)
+#else
+    ZEND_ARG_INFO(0, inside)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_clipImagePath, 0, 2, IS_VOID, 0)
-	ZEND_ARG_TYPE_INFO(0, pathname, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, inside, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_clipImagePath, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, pathname, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, pathname)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, inside, _IS_BOOL, 0)
+#else
+    ZEND_ARG_INFO(0, inside)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_coalesceImages arginfo_class_Imagick_clone
 
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_colorFloodfillImage, 0, 5, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_colorFloodfillImage, 0, 0, 5)
+#endif
+
 	ZEND_ARG_OBJ_TYPE_MASK(0, fill_color, ImagickPixel, MAY_BE_STRING, NULL)
-	ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, fuzz)
+#endif
 	ZEND_ARG_OBJ_TYPE_MASK(0, border_color, ImagickPixel, MAY_BE_STRING, NULL)
-	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, x)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, y)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_colorizeImage, 0, 2, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_colorizeImage, 0, 0, 2)
+#endif
+
 	ZEND_ARG_OBJ_TYPE_MASK(0, colorize_color, ImagickPixel, MAY_BE_STRING, NULL)
 	ZEND_ARG_OBJ_TYPE_MASK(0, opacity_color, ImagickPixel, MAY_BE_STRING|MAY_BE_FALSE, NULL)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 1, "false")
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 1, "false")
+#else
+    ZEND_ARG_INFO(0, legacy)
+#endif
+
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_compareImageChannels, 0, 3, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_compareImageChannels, 0, 0, 3)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, reference, Imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, channel)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, metric)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_compareImages, 0, 2, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_compareImages, 0, 0, 2)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, reference, Imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, metric)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_contrastImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, sharpen, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_contrastImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, sharpen, _IS_BOOL, 0)
+#else
+    ZEND_ARG_INFO(0, sharpen)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_combineImages, 0, 1, Imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_combineImages, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, colorspace)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_convolveImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, kernel, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_convolveImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, kernel, IS_ARRAY, 0)
+#else
+    ZEND_ARG_INFO(0, kernel)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_cycleColormapImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, displace, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_cycleColormapImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, displace, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, displace)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_deconstructImages arginfo_class_Imagick_clone
@@ -1199,15 +3693,42 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_equalizeImage arginfo_class_Imagick_removeImage
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_evaluateImage, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, evaluate, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, constant, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_evaluateImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, evaluate, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, evaluate)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, constant, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, constant)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
 #if MagickLibVersion >= 0x687
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_evaluateImages, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, evaluate, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_evaluateImages, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, evaluate, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, evaluate)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
@@ -1218,79 +3739,246 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_Imagick_flopImage arginfo_class_Imagick_removeImage
 
 #if MagickLibVersion >= 0x655
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_forwardFourierTransformImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, magnitude, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_forwardFourierTransformImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, magnitude, _IS_BOOL, 0)
+#else
+    ZEND_ARG_INFO(0, magnitude)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_frameImage, 0, 5, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_frameImage, 0, 0, 5)
+#endif
+
 	ZEND_ARG_OBJ_TYPE_MASK(0, matte_color, ImagickPixel, MAY_BE_STRING, NULL)
-	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, inner_bevel, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, outer_bevel, IS_LONG, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, width)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, height)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, inner_bevel, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, inner_bevel)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, outer_bevel, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, outer_bevel)
+#endif
 ZEND_END_ARG_INFO()
 
 #if MagickLibVersion >= 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_frameImageWithComposite, 0, 6, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_frameImageWithComposite, 0, 0, 6)
+#endif
+
 	ZEND_ARG_OBJ_TYPE_MASK(0, matte_color, ImagickPixel, MAY_BE_STRING, NULL)
-	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, inner_bevel, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, outer_bevel, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, composite, IS_LONG, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, width)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, height)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, inner_bevel, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, inner_bevel)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, outer_bevel, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, outer_bevel)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, composite, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, composite)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_fxImage, 0, 1, Imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, expression, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_fxImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, expression, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, expression)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_gammaImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, gamma, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_gammaImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, gamma, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, gamma)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_gaussianBlurImage arginfo_class_Imagick_blurImage
 
 #if MagickLibVersion < 0x700 && !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageAttribute, 0, 1, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageAttribute, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, key)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getImageBackgroundColor, 0, 0, ImagickPixel, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageBackgroundColor, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageBluePrimary arginfo_class_Imagick_getImageGeometry
 
 #define arginfo_class_Imagick_getImageBorderColor arginfo_class_Imagick_getImageBackgroundColor
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageChannelDepth, 0, 1, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageChannelDepth, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, channel)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageChannelDistortion, 0, 3, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageChannelDistortion, 0, 0, 3)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, reference, Imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, channel)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, metric)
+#endif
 ZEND_END_ARG_INFO()
 
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageChannelExtrema, 0, 1, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageChannelExtrema, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, channel)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageChannelMean, 0, 1, IS_ARRAY, 0)
-	ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageChannelMean, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, channel)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageChannelStatistics arginfo_class_Imagick_getImageGeometry
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getImageColormapColor, 0, 1, ImagickPixel, 0)
-	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageColormapColor, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, index)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageColorspace arginfo_class_Imagick_getImageSize
@@ -1301,19 +3989,42 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageDepth arginfo_class_Imagick_getImageSize
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageDistortion, 0, 2, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageDistortion, 0, 0, 2)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, reference, Imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, metric)
+#endif
 ZEND_END_ARG_INFO()
 
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageExtrema, 0, 0, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageExtrema, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
 #define arginfo_class_Imagick_getImageDispose arginfo_class_Imagick_getImageSize
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageGamma, 0, 0, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageGamma, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageGreenPrimary arginfo_class_Imagick_getImageGeometry
@@ -1327,27 +4038,76 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_Imagick_getImageIterations arginfo_class_Imagick_getImageSize
 
 #if MagickLibVersion < 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getImageMatteColor, 0, 0, ImagickPixel, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageMatteColor, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
 #define arginfo_class_Imagick_getImagePage arginfo_class_Imagick_getImageGeometry
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getImagePixelColor, 0, 2, ImagickPixel, 0)
-	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImagePixelColor, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, x)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, y)
+#endif
 ZEND_END_ARG_INFO()
 
 #if IM_HAVE_IMAGICK_SETIMAGEPIXELCOLOR
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_setImagePixelColor, 0, 3, ImagickPixel, 0)
-	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImagePixelColor, 0, 0, 3)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, x)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, y)
+#endif
 	ZEND_ARG_OBJ_TYPE_MASK(0, color, ImagickPixel, MAY_BE_STRING, NULL)
 ZEND_END_ARG_INFO()
 #endif
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageProfile, 0, 1, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageProfile, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, name)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageRedPrimary arginfo_class_Imagick_getImageGeometry
@@ -1376,230 +4136,743 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageTotalInkDensity arginfo_class_Imagick_getImageGamma
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getImageRegion, 0, 4, Imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageRegion, 0, 0, 4)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, width)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, height)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, x)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, y)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_implodeImage arginfo_class_Imagick_oilPaintImage
 
 #if MagickLibVersion >= 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_implodeImageWithMethod, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, pixel_interpolate_method, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_implodeImageWithMethod, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, radius)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, pixel_interpolate_method, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, pixel_interpolate_method)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion >= 0x658
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_inverseFourierTransformImage, 0, 2, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_inverseFourierTransformImage, 0, 0, 2)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, complement, Imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, magnitude, _IS_BOOL, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, magnitude, _IS_BOOL, 0)
+#else
+    ZEND_ARG_INFO(0, magnitude)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_levelImage, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, black_point, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, gamma, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, white_point, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_levelImage, 0, 0, 3)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, black_point, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, black_point)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, gamma, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, gamma)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, white_point, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, white_point)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_magnifyImage arginfo_class_Imagick_removeImage
 
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_mapImage, 0, 2, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_mapImage, 0, 0, 2)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, map, imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, dither, _IS_BOOL, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, dither, _IS_BOOL, 0)
+#else
+    ZEND_ARG_INFO(0, dither)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_matteFloodfillImage, 0, 5, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, alpha, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_matteFloodfillImage, 0, 0, 5)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, alpha, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, alpha)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, fuzz)
+#endif
 	ZEND_ARG_OBJ_TYPE_MASK(0, border_color, ImagickPixel, MAY_BE_STRING, NULL)
-	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, x)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, y)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion < 0x700 && !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_medianFilterImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_medianFilterImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, radius)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_negateImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, gray, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_negateImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, gray, _IS_BOOL, 0)
+#else
+    ZEND_ARG_INFO(0, gray)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_paintOpaqueImage, 0, 3, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_paintOpaqueImage, 0, 0, 3)
+#endif
+
 	ZEND_ARG_OBJ_TYPE_MASK(0, target_color, ImagickPixel, MAY_BE_STRING, NULL)
 	ZEND_ARG_OBJ_TYPE_MASK(0, fill_color, ImagickPixel, MAY_BE_STRING, NULL)
-	ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, fuzz)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_paintTransparentImage, 0, 3, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_paintTransparentImage, 0, 0, 3)
+#endif
+
 	ZEND_ARG_OBJ_TYPE_MASK(0, target_color, ImagickPixel, MAY_BE_STRING, NULL)
-	ZEND_ARG_TYPE_INFO(0, alpha, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, alpha, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, alpha)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, fuzz)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_previewImages, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, preview, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_previewImages, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, preview, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, preview)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_profileImage, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, profile, IS_STRING, 1)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_profileImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, name)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, profile, IS_STRING, 1)
+#else
+    ZEND_ARG_INFO(0, profile)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_quantizeImage, 0, 5, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, number_colors, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, tree_depth, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, dither, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, measure_error, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_quantizeImage, 0, 0, 5)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, number_colors, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, number_colors)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, colorspace)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, tree_depth, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, tree_depth)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, dither, _IS_BOOL, 0)
+#else
+    ZEND_ARG_INFO(0, dither)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, measure_error, _IS_BOOL, 0)
+#else
+    ZEND_ARG_INFO(0, measure_error)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_quantizeImages arginfo_class_Imagick_quantizeImage
 
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_reduceNoiseImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_reduceNoiseImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, radius)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #define arginfo_class_Imagick_removeImageProfile arginfo_class_Imagick_getImageProfile
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_separateImageChannel, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_separateImageChannel, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, channel)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_sepiaToneImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_sepiaToneImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, threshold)
+#endif
 ZEND_END_ARG_INFO()
 
 #if MagickLibVersion < 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageBias, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, bias, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageBias, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, bias, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, bias)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion < 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageBiasQuantum, 0, 1, IS_VOID, 0)
-	ZEND_ARG_TYPE_INFO(0, bias, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageBiasQuantum, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, bias, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, bias)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageBluePrimary, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, x, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, y, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageBluePrimary, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, x)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, y)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageBorderColor, 0, 1, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageBorderColor, 0, 0, 1)
+#endif
+
 	ZEND_ARG_OBJ_TYPE_MASK(0, border_color, ImagickPixel, MAY_BE_STRING, NULL)
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageChannelDepth, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, depth, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageChannelDepth, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, channel)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, depth, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, depth)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageColormapColor, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageColormapColor, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, index)
+#endif
 	ZEND_ARG_OBJ_TYPE_MASK(0, color, ImagickPixel, MAY_BE_STRING, NULL)
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageColorspace, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageColorspace, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, colorspace)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageDispose, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, dispose, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageDispose, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, dispose, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, dispose)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_setImageExtent arginfo_class_Imagick_sampleImage
 
 #define arginfo_class_Imagick_setImageGreenPrimary arginfo_class_Imagick_setImageBluePrimary
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageInterlaceScheme, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, interlace, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageInterlaceScheme, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, interlace, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, interlace)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageProfile, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, profile, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageProfile, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, name)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, profile, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, profile)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_setImageRedPrimary arginfo_class_Imagick_setImageBluePrimary
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageRenderingIntent, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, rendering_intent, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageRenderingIntent, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, rendering_intent, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, rendering_intent)
+#endif
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageVirtualPixelMethod, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, method, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageVirtualPixelMethod, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, method, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, method)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_setImageWhitePoint arginfo_class_Imagick_setImageBluePrimary
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_sigmoidalContrastImage, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, sharpen, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, alpha, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, beta, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_sigmoidalContrastImage, 0, 0, 3)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, sharpen, _IS_BOOL, 0)
+#else
+    ZEND_ARG_INFO(0, sharpen)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, alpha, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, alpha)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, beta, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, beta)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_stereoImage, 0, 1, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_stereoImage, 0, 0, 1)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, offset_image, Imagick, 0)
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_textureImage, 0, 1, Imagick, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_textureImage, 0, 0, 1)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, texture, Imagick, 0)
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_tintImage, 0, 2, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_tintImage, 0, 0, 2)
+#endif
+
 	ZEND_ARG_OBJ_TYPE_MASK(0, tint_color, ImagickPixel, MAY_BE_STRING, NULL)
 	ZEND_ARG_OBJ_TYPE_MASK(0, opacity_color, ImagickPixel, MAY_BE_STRING, NULL)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
+#else
+    ZEND_ARG_INFO(0, legacy)
+#endif
+
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_unsharpMaskImage, 0, 4, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, amount, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_unsharpMaskImage, 0, 0, 4)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, radius)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, sigma)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, amount, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, amount)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, threshold)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImage arginfo_class_Imagick_clone
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_addImage, 0, 1, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_addImage, 0, 0, 1)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, image, Imagick, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_setImage arginfo_class_Imagick_addImage
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_newImage, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_newImage, 0, 0, 3)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, columns)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, rows)
+#endif
 	ZEND_ARG_OBJ_TYPE_MASK(0, background_color, ImagickPixel, MAY_BE_STRING, NULL)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, format, IS_STRING, 0, "null")
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, format, IS_STRING, 0, "null")
+#else
+    ZEND_ARG_INFO(0, format)
+#endif
+
 ZEND_END_ARG_INFO()
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_newPseudoImage, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, pseudo_format, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_newPseudoImage, 0, 0, 3)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, columns)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, rows)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, pseudo_format, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, pseudo_format)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getCompression arginfo_class_Imagick_getImageSize
@@ -1611,7 +4884,13 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_Imagick_getConfigureOptions arginfo_class_Imagick_queryFormats
 
 #if MagickLibVersion > 0x660
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getFeatures, 0, 0, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getFeatures, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
@@ -1623,8 +4902,19 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getInterlaceScheme arginfo_class_Imagick_getImageSize
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getOption, 0, 1, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getOption, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, key)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getPackageName arginfo_class_Imagick___toString
@@ -1641,8 +4931,19 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getReleaseDate arginfo_class_Imagick___toString
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getResource, 0, 1, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getResource, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, type)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getResourceLimit arginfo_class_Imagick_getResource
@@ -1665,418 +4966,1079 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_setInterlaceScheme arginfo_class_Imagick_setImageInterlaceScheme
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setOption, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setOption, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, key)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, value)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_setPage arginfo_class_Imagick_cropImage
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setResourceLimit, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, limit, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setResourceLimit, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, type)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, limit, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, limit)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_setResolution arginfo_class_Imagick_setImageResolution
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setSamplingFactors, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, factors, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setSamplingFactors, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, factors, IS_ARRAY, 0)
+#else
+    ZEND_ARG_INFO(0, factors)
+#endif
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_setSize arginfo_class_Imagick_sampleImage
 
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setType, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, imgtype, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setType, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, imgtype, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, imgtype)
+#endif
 ZEND_END_ARG_INFO()
 
 #if MagickLibVersion > 0x628
 #define arginfo_class_Imagick_key arginfo_class_Imagick_getSizeOffset
 #endif
 
-#if MagickLibVersion > 0x628
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_next, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if MagickLibVersion > 0x628
 #define arginfo_class_Imagick_rewind arginfo_class_Imagick_next
-#endif
 
-#if MagickLibVersion > 0x628
-#define arginfo_class_Imagick_valid arginfo_class_Imagick_optimizeImageLayers
-#endif
+#define arginfo_class_Imagick_valid arginfo_class_Imagick_removeImage
 
-#if MagickLibVersion > 0x628
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_current, 0, 0, Imagick, 0)
-ZEND_END_ARG_INFO()
-#endif
+#define arginfo_class_Imagick_current arginfo_class_Imagick_clone
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x659
+#if MagickLibVersion >= 0x659
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_brightnessContrastImage, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, brightness, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, contrast, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_brightnessContrastImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, brightness, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, brightness)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, contrast, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, contrast)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion > 0x661
+#if MagickLibVersion > 0x661
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_colorMatrixImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, color_matrix, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_colorMatrixImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, color_matrix, IS_ARRAY, 0)
+#else
+    ZEND_ARG_INFO(0, color_matrix)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_selectiveBlurImage, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
-ZEND_END_ARG_INFO()
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_selectiveBlurImage, 0, 0, 3)
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x689
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, radius)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, sigma)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, threshold)
+#endif
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
+ZEND_END_ARG_INFO()
+
+#if MagickLibVersion >= 0x689
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_rotationalBlurImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_rotationalBlurImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, angle)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x683
+#if MagickLibVersion >= 0x683
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_statisticImage, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_statisticImage, 0, 0, 3)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, type)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, width)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, height)
+#endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x652
+#if MagickLibVersion >= 0x652
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_subimageMatch, 0, 1, Imagick, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_subimageMatch, 0, 0, 1)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, image, Imagick, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(1, offset, IS_ARRAY, 1, "null")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(1, similarity, IS_DOUBLE, 1, "null")
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(1, offset, IS_ARRAY, 1, "null")
+#else
+    ZEND_ARG_INFO(1, offset)
+#endif
+
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(1, similarity, IS_DOUBLE, 1, "null")
+#else
+    ZEND_ARG_INFO(1, similarity)
+#endif
+
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, threshold, IS_DOUBLE, 0, "0.0")
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, metric, IS_LONG, 0, "0")
+
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, metric, IS_LONG, 0, "0")
+#else
+    ZEND_ARG_INFO(0, metric)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x652
+#if MagickLibVersion >= 0x652
 #define arginfo_class_Imagick_similarityImage arginfo_class_Imagick_subimageMatch
 #endif
 
-#if MagickLibVersion > 0x628
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setRegistry, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
-ZEND_END_ARG_INFO()
-#endif
+#define arginfo_class_Imagick_setRegistry arginfo_class_Imagick_setOption
 
-#if MagickLibVersion > 0x628
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getRegistry, 0, 1, IS_STRING, 0)
-	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
-ZEND_END_ARG_INFO()
-#endif
+#define arginfo_class_Imagick_getRegistry arginfo_class_Imagick_getOption
 
-#if MagickLibVersion > 0x628
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_listRegistry, 0, 0, IS_ARRAY, 0)
-ZEND_END_ARG_INFO()
-#endif
+#define arginfo_class_Imagick_listRegistry arginfo_class_Imagick_getImageGeometry
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x680
+#if MagickLibVersion >= 0x680
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_morphology, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, morphology, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, iterations, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_morphology, 0, 0, 3)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, morphology, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, morphology)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, iterations, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, iterations)
+#endif
 	ZEND_ARG_OBJ_INFO(0, kernel, ImagickKernel, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && defined(IMAGICK_WITH_KERNEL) && MagickLibVersion < 0x700
+#if defined(IMAGICK_WITH_KERNEL) && MagickLibVersion < 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_filter, 0, 1, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_filter, 0, 0, 1)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, kernel, ImagickKernel, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_UNDEFINED")
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setAntialias, 0, 1, IS_VOID, 0)
-	ZEND_ARG_TYPE_INFO(0, antialias, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setAntialias, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, antialias, _IS_BOOL, 0)
+#else
+    ZEND_ARG_INFO(0, antialias)
+#endif
 ZEND_END_ARG_INFO()
-#endif
 
-#if MagickLibVersion > 0x628
-#define arginfo_class_Imagick_getAntialias arginfo_class_Imagick_optimizeImageLayers
-#endif
+#define arginfo_class_Imagick_getAntialias arginfo_class_Imagick_removeImage
 
-#if MagickLibVersion > 0x628 && MagickLibVersion > 0x676
+#if MagickLibVersion > 0x676
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_colorDecisionListImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, color_correction_collection, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_colorDecisionListImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, color_correction_collection, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, color_correction_collection)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x687
+#if MagickLibVersion >= 0x687
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_optimizeImageTransparency, 0, 0, IS_VOID, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_optimizeImageTransparency, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x660
+#if MagickLibVersion >= 0x660
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_autoGammaImage, 0, 0, IS_VOID, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_autoGammaImage, 0, 0, 0)
+#endif
+
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 1, "Imagick::CHANNEL_ALL")
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
+#if MagickLibVersion >= 0x692
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_autoOrient, 0, 0, IS_VOID, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_autoOrient, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
+#if MagickLibVersion >= 0x692
 #define arginfo_class_Imagick_autoOrientate arginfo_class_Imagick_autoOrient
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
+#if MagickLibVersion >= 0x692
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_compositeImageGravity, 0, 3, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_compositeImageGravity, 0, 0, 3)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, image, Imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, composite_constant, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, gravity, IS_LONG, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, composite_constant, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, composite_constant)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, gravity, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, gravity)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x693
+#if MagickLibVersion >= 0x693
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_localContrastImage, 0, 2, IS_VOID, 0)
-	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, strength, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_localContrastImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, radius)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, strength, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, strength)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x700
+#if MagickLibVersion >= 0x700
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_identifyImageType, 0, 0, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_identifyImageType, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GETSETIMAGEMASK
+#if IM_HAVE_IMAGICK_GETSETIMAGEMASK
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getImageMask, 0, 1, Imagick, 1)
-	ZEND_ARG_TYPE_INFO(0, pixelmask, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageMask, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, pixelmask, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, pixelmask)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GETSETIMAGEMASK
+#if IM_HAVE_IMAGICK_GETSETIMAGEMASK
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageMask, 0, 2, IS_VOID, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageMask, 0, 0, 2)
+#endif
+
 	ZEND_ARG_OBJ_INFO(0, clip_mask, Imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, pixelmask, IS_LONG, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, pixelmask, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, pixelmask)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x709
+#if MagickLibVersion >= 0x709
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_cannyEdgeImage, 0, 4, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, lower_percent, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, upper_percent, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_cannyEdgeImage, 0, 0, 4)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, radius)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, sigma)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, lower_percent, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, lower_percent)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, upper_percent, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, upper_percent)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SETSEED
+#if IM_HAVE_IMAGICK_SETSEED
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setSeed, 0, 1, IS_VOID, 0)
-	ZEND_ARG_TYPE_INFO(0, seed, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setSeed, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, seed, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, seed)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_WAVELETDENOISEIMAGE
+#if IM_HAVE_IMAGICK_WAVELETDENOISEIMAGE
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_waveletDenoiseImage, 0, 2, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, softness, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_waveletDenoiseImage, 0, 0, 2)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, threshold)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, softness, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, softness)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_MEANSHIFTIMAGE
+#if IM_HAVE_IMAGICK_MEANSHIFTIMAGE
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_meanShiftImage, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, color_distance, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_meanShiftImage, 0, 0, 3)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, width)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, height)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, color_distance, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, color_distance)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_KMEANSIMAGE
+#if IM_HAVE_IMAGICK_KMEANSIMAGE
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_kmeansImage, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, number_colors, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, max_iterations, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, tolerance, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_kmeansImage, 0, 0, 3)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, number_colors, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, number_colors)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, max_iterations, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, max_iterations)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, tolerance, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, tolerance)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_RANGETHRESHOLDIMAGE
+#if IM_HAVE_IMAGICK_RANGETHRESHOLDIMAGE
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_rangeThresholdImage, 0, 4, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, low_black, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, low_white, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, high_white, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, high_black, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_rangeThresholdImage, 0, 0, 4)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, low_black, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, low_black)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, low_white, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, low_white)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, high_white, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, high_white)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, high_black, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, high_black)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_AUTOTHRESHOLDIMAGE
+#if IM_HAVE_IMAGICK_AUTOTHRESHOLDIMAGE
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_autoThresholdImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, auto_threshold_method, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_autoThresholdImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, auto_threshold_method, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, auto_threshold_method)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_BILATERALBLURIMAGE
+#if IM_HAVE_IMAGICK_BILATERALBLURIMAGE
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_bilateralBlurImage, 0, 4, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, intensity_sigma, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, spatial_sigma, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_bilateralBlurImage, 0, 0, 4)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, radius)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, sigma)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, intensity_sigma, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, intensity_sigma)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, spatial_sigma, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, spatial_sigma)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_CLAHEIMAGE
+#if IM_HAVE_IMAGICK_CLAHEIMAGE
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_claheImage, 0, 4, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, number_bins, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, clip_limit, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_claheImage, 0, 0, 4)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, width)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, height)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, number_bins, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, number_bins)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, clip_limit, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, clip_limit)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_CHANNELFXIMAGE
+#if IM_HAVE_IMAGICK_CHANNELFXIMAGE
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_channelFxImage, 0, 1, Imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, expression, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_channelFxImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, expression, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, expression)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_COLORTHRESHOLDIMAGE
+#if IM_HAVE_IMAGICK_COLORTHRESHOLDIMAGE
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_colorThresholdImage, 0, 2, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_colorThresholdImage, 0, 0, 2)
+#endif
+
 	ZEND_ARG_OBJ_TYPE_MASK(0, start_color, ImagickPixel, MAY_BE_STRING, NULL)
 	ZEND_ARG_OBJ_TYPE_MASK(0, stop_color, ImagickPixel, MAY_BE_STRING, NULL)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_COMPLEXIMAGES
+#if IM_HAVE_IMAGICK_COMPLEXIMAGES
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_complexImages, 0, 1, Imagick, 0)
-	ZEND_ARG_TYPE_INFO(0, complex_operator, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_complexImages, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, complex_operator, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, complex_operator)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_INTERPOLATIVERESIZEIMAGE
+#if IM_HAVE_IMAGICK_INTERPOLATIVERESIZEIMAGE
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_interpolativeResizeImage, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO(0, interpolate, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_interpolativeResizeImage, 0, 0, 3)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, columns)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, rows)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, interpolate, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, interpolate)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_LEVELIMAGECOLORS
+#if IM_HAVE_IMAGICK_LEVELIMAGECOLORS
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_levelImageColors, 0, 3, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_levelImageColors, 0, 0, 3)
+#endif
+
 	ZEND_ARG_OBJ_TYPE_MASK(0, black_color, ImagickPixel, MAY_BE_STRING, NULL)
 	ZEND_ARG_OBJ_TYPE_MASK(0, white_color, ImagickPixel, MAY_BE_STRING, NULL)
-	ZEND_ARG_TYPE_INFO(0, invert, _IS_BOOL, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, invert, _IS_BOOL, 0)
+#else
+    ZEND_ARG_INFO(0, invert)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_LEVELIZEIMAGE
+#if IM_HAVE_IMAGICK_LEVELIZEIMAGE
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_levelizeImage, 0, 3, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, black_point, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, gamma, IS_DOUBLE, 0)
-	ZEND_ARG_TYPE_INFO(0, white_point, IS_DOUBLE, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_levelizeImage, 0, 0, 3)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, black_point, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, black_point)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, gamma, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, gamma)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, white_point, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, white_point)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_ORDEREDDITHERIMAGE
+#if IM_HAVE_IMAGICK_ORDEREDDITHERIMAGE
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_orderedDitherImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, dither_format, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_orderedDitherImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, dither_format, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, dither_format)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_WHITEBALANCEIMAGE
+#if IM_HAVE_IMAGICK_WHITEBALANCEIMAGE
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_whiteBalanceImage, 0, 0, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_whiteBalanceImage, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_DELETE_OPTION
+#if IM_HAVE_IMAGICK_DELETE_OPTION
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_deleteOption, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, option, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_deleteOption, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, option, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, option)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_BACKGROUND_COLOR
+#if IM_HAVE_IMAGICK_GET_BACKGROUND_COLOR
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getBackgroundColor, 0, 0, ImagickPixel, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getBackgroundColor, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_ARTIFACTS
+#if IM_HAVE_IMAGICK_GET_IMAGE_ARTIFACTS
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageArtifacts, 0, 0, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageArtifacts, 0, 0, 0)
+#endif
+
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, pattern, IS_STRING, 0, "\"*\"")
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_KURTOSIS
+#if IM_HAVE_IMAGICK_GET_IMAGE_KURTOSIS
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageKurtosis, 0, 0, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageKurtosis, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_MEAN
+#if IM_HAVE_IMAGICK_GET_IMAGE_MEAN
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageMean, 0, 0, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageMean, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_RANGE
+#if IM_HAVE_IMAGICK_GET_IMAGE_RANGE
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageRange, 0, 0, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageRange, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_INTERPOLATE_METHOD
+#if IM_HAVE_IMAGICK_GET_INTERPOLATE_METHOD
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getInterpolateMethod, 0, 0, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getInterpolateMethod, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_OPTIONS
+#if IM_HAVE_IMAGICK_GET_OPTIONS
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getOptions, 0, 0, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getOptions, 0, 0, 0)
+#endif
+
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, pattern, IS_STRING, 0, "\"*\"")
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_ORIENTATION
+#if IM_HAVE_IMAGICK_GET_ORIENTATION
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getOrientation, 0, 0, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getOrientation, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_RESOLUTION
+#if IM_HAVE_IMAGICK_GET_RESOLUTION
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getResolution, 0, 0, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getResolution, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_TYPE
+#if IM_HAVE_IMAGICK_GET_TYPE
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getType, 0, 0, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getType, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_POLYNOMIAL_IMAGE
+#if IM_HAVE_IMAGICK_POLYNOMIAL_IMAGE
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_polynomialImage, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, terms, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_polynomialImage, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, terms, IS_ARRAY, 0)
+#else
+    ZEND_ARG_INFO(0, terms)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_DEPTH
+#if IM_HAVE_IMAGICK_SET_DEPTH
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setDepth, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, depth, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setDepth, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, depth, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, depth)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_EXTRACT
+#if IM_HAVE_IMAGICK_SET_EXTRACT
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setExtract, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, geometry, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setExtract, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, geometry, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, geometry)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_INTERPOLATE_METHOD
+#if IM_HAVE_IMAGICK_SET_INTERPOLATE_METHOD
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setInterpolateMethod, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, method, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setInterpolateMethod, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, method, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, method)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_ORIENTATION
+#if IM_HAVE_IMAGICK_SET_ORIENTATION
+
+#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setOrientation, 0, 1, _IS_BOOL, 0)
-	ZEND_ARG_TYPE_INFO(0, orientation, IS_LONG, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setOrientation, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, orientation, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, orientation)
+#endif
 ZEND_END_ARG_INFO()
 #endif
 
@@ -2213,7 +6175,7 @@ ZEND_METHOD(Imagick, paintFloodfillImage);
 #if MagickLibVersion > 0x635
 ZEND_METHOD(Imagick, clutImage);
 #endif
-#if MagickLibVersion > 0x635 && MagickLibVersion > 0x700
+#if MagickLibVersion > 0x635 && MagickLibVersion >= 0x700
 ZEND_METHOD(Imagick, clutImageWithInterpolate);
 #endif
 #if MagickLibVersion > 0x635
@@ -2694,217 +6656,242 @@ ZEND_METHOD(Imagick, setResolution);
 ZEND_METHOD(Imagick, setSamplingFactors);
 ZEND_METHOD(Imagick, setSize);
 ZEND_METHOD(Imagick, setType);
-#if MagickLibVersion > 0x628
-ZEND_METHOD(Imagick, nextImage);
-#endif
-#if MagickLibVersion > 0x628
-ZEND_METHOD(Imagick, setFirstIterator);
-#endif
-#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, valid);
-#endif
-#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, current);
-#endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x659
+#if MagickLibVersion >= 0x659
 ZEND_METHOD(Imagick, brightnessContrastImage);
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion > 0x661
+#if MagickLibVersion > 0x661
 ZEND_METHOD(Imagick, colorMatrixImage);
 #endif
-#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, selectiveBlurImage);
-#endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x689
+#if MagickLibVersion >= 0x689
 ZEND_METHOD(Imagick, rotationalBlurImage);
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x683
+#if MagickLibVersion >= 0x683
 ZEND_METHOD(Imagick, statisticImage);
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x652
+#if MagickLibVersion >= 0x652
 ZEND_METHOD(Imagick, subimageMatch);
 #endif
-#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, setRegistry);
-#endif
-#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, getRegistry);
-#endif
-#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, listRegistry);
-#endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x680
+#if MagickLibVersion >= 0x680
 ZEND_METHOD(Imagick, morphology);
 #endif
-#if MagickLibVersion > 0x628 && defined(IMAGICK_WITH_KERNEL) && MagickLibVersion < 0x700
+#if defined(IMAGICK_WITH_KERNEL) && MagickLibVersion < 0x700
 ZEND_METHOD(Imagick, filter);
 #endif
-#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, setAntialias);
-#endif
-#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, getAntialias);
-#endif
-#if MagickLibVersion > 0x628 && MagickLibVersion > 0x676
+#if MagickLibVersion > 0x676
 ZEND_METHOD(Imagick, colorDecisionListImage);
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x687
+#if MagickLibVersion >= 0x687
 ZEND_METHOD(Imagick, optimizeImageTransparency);
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x660
+#if MagickLibVersion >= 0x660
 ZEND_METHOD(Imagick, autoGammaImage);
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
+#if MagickLibVersion >= 0x692
 ZEND_METHOD(Imagick, autoOrient);
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
+#if MagickLibVersion >= 0x692
 ZEND_METHOD(Imagick, compositeImageGravity);
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x693
+#if MagickLibVersion >= 0x693
 ZEND_METHOD(Imagick, localContrastImage);
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x700
+#if MagickLibVersion >= 0x700
 ZEND_METHOD(Imagick, identifyImageType);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GETSETIMAGEMASK
+#if IM_HAVE_IMAGICK_GETSETIMAGEMASK
 ZEND_METHOD(Imagick, getImageMask);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GETSETIMAGEMASK
+#if IM_HAVE_IMAGICK_GETSETIMAGEMASK
 ZEND_METHOD(Imagick, setImageMask);
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x709
+#if MagickLibVersion >= 0x709
 ZEND_METHOD(Imagick, cannyEdgeImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SETSEED
+#if IM_HAVE_IMAGICK_SETSEED
 ZEND_METHOD(Imagick, setSeed);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_WAVELETDENOISEIMAGE
+#if IM_HAVE_IMAGICK_WAVELETDENOISEIMAGE
 ZEND_METHOD(Imagick, waveletDenoiseImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_MEANSHIFTIMAGE
+#if IM_HAVE_IMAGICK_MEANSHIFTIMAGE
 ZEND_METHOD(Imagick, meanShiftImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_KMEANSIMAGE
+#if IM_HAVE_IMAGICK_KMEANSIMAGE
 ZEND_METHOD(Imagick, kmeansImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_RANGETHRESHOLDIMAGE
+#if IM_HAVE_IMAGICK_RANGETHRESHOLDIMAGE
 ZEND_METHOD(Imagick, rangeThresholdImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_AUTOTHRESHOLDIMAGE
+#if IM_HAVE_IMAGICK_AUTOTHRESHOLDIMAGE
 ZEND_METHOD(Imagick, autoThresholdImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_BILATERALBLURIMAGE
+#if IM_HAVE_IMAGICK_BILATERALBLURIMAGE
 ZEND_METHOD(Imagick, bilateralBlurImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_CLAHEIMAGE
+#if IM_HAVE_IMAGICK_CLAHEIMAGE
 ZEND_METHOD(Imagick, claheImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_CHANNELFXIMAGE
+#if IM_HAVE_IMAGICK_CHANNELFXIMAGE
 ZEND_METHOD(Imagick, channelFxImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_COLORTHRESHOLDIMAGE
+#if IM_HAVE_IMAGICK_COLORTHRESHOLDIMAGE
 ZEND_METHOD(Imagick, colorThresholdImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_COMPLEXIMAGES
+#if IM_HAVE_IMAGICK_COMPLEXIMAGES
 ZEND_METHOD(Imagick, complexImages);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_INTERPOLATIVERESIZEIMAGE
+#if IM_HAVE_IMAGICK_INTERPOLATIVERESIZEIMAGE
 ZEND_METHOD(Imagick, interpolativeResizeImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_LEVELIMAGECOLORS
+#if IM_HAVE_IMAGICK_LEVELIMAGECOLORS
 ZEND_METHOD(Imagick, levelImageColors);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_LEVELIZEIMAGE
+#if IM_HAVE_IMAGICK_LEVELIZEIMAGE
 ZEND_METHOD(Imagick, levelizeImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_ORDEREDDITHERIMAGE
+#if IM_HAVE_IMAGICK_ORDEREDDITHERIMAGE
 ZEND_METHOD(Imagick, orderedDitherImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_WHITEBALANCEIMAGE
+#if IM_HAVE_IMAGICK_WHITEBALANCEIMAGE
 ZEND_METHOD(Imagick, whiteBalanceImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_DELETE_OPTION
+#if IM_HAVE_IMAGICK_DELETE_OPTION
 ZEND_METHOD(Imagick, deleteOption);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_BACKGROUND_COLOR
+#if IM_HAVE_IMAGICK_GET_BACKGROUND_COLOR
 ZEND_METHOD(Imagick, getBackgroundColor);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_ARTIFACTS
+#if IM_HAVE_IMAGICK_GET_IMAGE_ARTIFACTS
 ZEND_METHOD(Imagick, getImageArtifacts);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_KURTOSIS
+#if IM_HAVE_IMAGICK_GET_IMAGE_KURTOSIS
 ZEND_METHOD(Imagick, getImageKurtosis);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_MEAN
+#if IM_HAVE_IMAGICK_GET_IMAGE_MEAN
 ZEND_METHOD(Imagick, getImageMean);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_RANGE
+#if IM_HAVE_IMAGICK_GET_IMAGE_RANGE
 ZEND_METHOD(Imagick, getImageRange);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_INTERPOLATE_METHOD
+#if IM_HAVE_IMAGICK_GET_INTERPOLATE_METHOD
 ZEND_METHOD(Imagick, getInterpolateMethod);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_OPTIONS
+#if IM_HAVE_IMAGICK_GET_OPTIONS
 ZEND_METHOD(Imagick, getOptions);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_ORIENTATION
+#if IM_HAVE_IMAGICK_GET_ORIENTATION
 ZEND_METHOD(Imagick, getOrientation);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_RESOLUTION
+#if IM_HAVE_IMAGICK_GET_RESOLUTION
 ZEND_METHOD(Imagick, getResolution);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_TYPE
+#if IM_HAVE_IMAGICK_GET_TYPE
 ZEND_METHOD(Imagick, getType);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_POLYNOMIAL_IMAGE
+#if IM_HAVE_IMAGICK_POLYNOMIAL_IMAGE
 ZEND_METHOD(Imagick, polynomialImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_DEPTH
+#if IM_HAVE_IMAGICK_SET_DEPTH
 ZEND_METHOD(Imagick, setDepth);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_EXTRACT
+#if IM_HAVE_IMAGICK_SET_EXTRACT
 ZEND_METHOD(Imagick, setExtract);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_INTERPOLATE_METHOD
+#if IM_HAVE_IMAGICK_SET_INTERPOLATE_METHOD
 ZEND_METHOD(Imagick, setInterpolateMethod);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_ORIENTATION
+#if IM_HAVE_IMAGICK_SET_ORIENTATION
 ZEND_METHOD(Imagick, setOrientation);
 #endif
 
 
-#if MagickLibVersion > 0x628
 static const zend_function_entry class_Imagick_methods[] = {
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, optimizeImageLayers, arginfo_class_Imagick_optimizeImageLayers, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, compareImageLayers, arginfo_class_Imagick_compareImageLayers, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, pingImageBlob, arginfo_class_Imagick_pingImageBlob, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, pingImageFile, arginfo_class_Imagick_pingImageFile, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, transposeImage, arginfo_class_Imagick_transposeImage, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, transverseImage, arginfo_class_Imagick_transverseImage, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, trimImage, arginfo_class_Imagick_trimImage, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, waveImage, arginfo_class_Imagick_waveImage, ZEND_ACC_PUBLIC)
+#endif
 #if MagickLibVersion > 0x628 && MagickLibVersion >= 0x700
 	ZEND_ME(Imagick, waveImageWithMethod, arginfo_class_Imagick_waveImageWithMethod, ZEND_ACC_PUBLIC)
 #endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, vignetteImage, arginfo_class_Imagick_vignetteImage, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, uniqueImageColors, arginfo_class_Imagick_uniqueImageColors, ZEND_ACC_PUBLIC)
+#endif
 #if MagickLibVersion > 0x628 && !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
 	ZEND_ME(Imagick, getImageMatte, arginfo_class_Imagick_getImageMatte, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
 #endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, setImageMatte, arginfo_class_Imagick_setImageMatte, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, adaptiveResizeImage, arginfo_class_Imagick_adaptiveResizeImage, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, sketchImage, arginfo_class_Imagick_sketchImage, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, shadeImage, arginfo_class_Imagick_shadeImage, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, getSizeOffset, arginfo_class_Imagick_getSizeOffset, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, setSizeOffset, arginfo_class_Imagick_setSizeOffset, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, adaptiveBlurImage, arginfo_class_Imagick_adaptiveBlurImage, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, contrastStretchImage, arginfo_class_Imagick_contrastStretchImage, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, adaptiveSharpenImage, arginfo_class_Imagick_adaptiveSharpenImage, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, randomThresholdImage, arginfo_class_Imagick_randomThresholdImage, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, roundCornersImage, arginfo_class_Imagick_roundCornersImage, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_MALIAS(Imagick, roundCorners, roundCornersImage, arginfo_class_Imagick_roundCorners, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, setIteratorIndex, arginfo_class_Imagick_setIteratorIndex, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, getIteratorIndex, arginfo_class_Imagick_getIteratorIndex, ZEND_ACC_PUBLIC)
+#endif
 #if MagickLibVersion > 0x628 && MagickLibVersion < 0x700
 	ZEND_ME(Imagick, transformImage, arginfo_class_Imagick_transformImage, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
 #endif
@@ -2962,7 +6949,7 @@ static const zend_function_entry class_Imagick_methods[] = {
 #if MagickLibVersion > 0x635
 	ZEND_ME(Imagick, clutImage, arginfo_class_Imagick_clutImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x635 && MagickLibVersion > 0x700
+#if MagickLibVersion > 0x635 && MagickLibVersion >= 0x700
 	ZEND_ME(Imagick, clutImageWithInterpolate, arginfo_class_Imagick_clutImageWithInterpolate, ZEND_ACC_PUBLIC)
 #endif
 #if MagickLibVersion > 0x635
@@ -3445,170 +7432,171 @@ static const zend_function_entry class_Imagick_methods[] = {
 	ZEND_ME(Imagick, setSamplingFactors, arginfo_class_Imagick_setSamplingFactors, ZEND_ACC_PUBLIC)
 	ZEND_ME(Imagick, setSize, arginfo_class_Imagick_setSize, ZEND_ACC_PUBLIC)
 	ZEND_ME(Imagick, setType, arginfo_class_Imagick_setType, ZEND_ACC_PUBLIC)
+#if MagickLibVersion > 0x628
 	ZEND_MALIAS(Imagick, key, getIteratorIndex, arginfo_class_Imagick_key, ZEND_ACC_PUBLIC)
+#endif
 	ZEND_MALIAS(Imagick, next, nextImage, arginfo_class_Imagick_next, ZEND_ACC_PUBLIC)
 	ZEND_MALIAS(Imagick, rewind, setFirstIterator, arginfo_class_Imagick_rewind, ZEND_ACC_PUBLIC)
 	ZEND_ME(Imagick, valid, arginfo_class_Imagick_valid, ZEND_ACC_PUBLIC)
 	ZEND_ME(Imagick, current, arginfo_class_Imagick_current, ZEND_ACC_PUBLIC)
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x659
+#if MagickLibVersion >= 0x659
 	ZEND_ME(Imagick, brightnessContrastImage, arginfo_class_Imagick_brightnessContrastImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion > 0x661
+#if MagickLibVersion > 0x661
 	ZEND_ME(Imagick, colorMatrixImage, arginfo_class_Imagick_colorMatrixImage, ZEND_ACC_PUBLIC)
 #endif
 	ZEND_ME(Imagick, selectiveBlurImage, arginfo_class_Imagick_selectiveBlurImage, ZEND_ACC_PUBLIC)
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x689
+#if MagickLibVersion >= 0x689
 	ZEND_ME(Imagick, rotationalBlurImage, arginfo_class_Imagick_rotationalBlurImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x683
+#if MagickLibVersion >= 0x683
 	ZEND_ME(Imagick, statisticImage, arginfo_class_Imagick_statisticImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x652
+#if MagickLibVersion >= 0x652
 	ZEND_ME(Imagick, subimageMatch, arginfo_class_Imagick_subimageMatch, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x652
+#if MagickLibVersion >= 0x652
 	ZEND_MALIAS(Imagick, similarityImage, subimageMatch, arginfo_class_Imagick_similarityImage, ZEND_ACC_PUBLIC)
 #endif
 	ZEND_ME(Imagick, setRegistry, arginfo_class_Imagick_setRegistry, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(Imagick, getRegistry, arginfo_class_Imagick_getRegistry, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_ME(Imagick, listRegistry, arginfo_class_Imagick_listRegistry, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x680
+#if MagickLibVersion >= 0x680
 	ZEND_ME(Imagick, morphology, arginfo_class_Imagick_morphology, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && defined(IMAGICK_WITH_KERNEL) && MagickLibVersion < 0x700
+#if defined(IMAGICK_WITH_KERNEL) && MagickLibVersion < 0x700
 	ZEND_ME(Imagick, filter, arginfo_class_Imagick_filter, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
 #endif
 	ZEND_ME(Imagick, setAntialias, arginfo_class_Imagick_setAntialias, ZEND_ACC_PUBLIC)
 	ZEND_ME(Imagick, getAntialias, arginfo_class_Imagick_getAntialias, ZEND_ACC_PUBLIC)
-#if MagickLibVersion > 0x628 && MagickLibVersion > 0x676
+#if MagickLibVersion > 0x676
 	ZEND_ME(Imagick, colorDecisionListImage, arginfo_class_Imagick_colorDecisionListImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x687
+#if MagickLibVersion >= 0x687
 	ZEND_ME(Imagick, optimizeImageTransparency, arginfo_class_Imagick_optimizeImageTransparency, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x660
+#if MagickLibVersion >= 0x660
 	ZEND_ME(Imagick, autoGammaImage, arginfo_class_Imagick_autoGammaImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
+#if MagickLibVersion >= 0x692
 	ZEND_ME(Imagick, autoOrient, arginfo_class_Imagick_autoOrient, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
+#if MagickLibVersion >= 0x692
 	ZEND_MALIAS(Imagick, autoOrientate, autoOrient, arginfo_class_Imagick_autoOrientate, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
+#if MagickLibVersion >= 0x692
 	ZEND_ME(Imagick, compositeImageGravity, arginfo_class_Imagick_compositeImageGravity, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x693
+#if MagickLibVersion >= 0x693
 	ZEND_ME(Imagick, localContrastImage, arginfo_class_Imagick_localContrastImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x700
+#if MagickLibVersion >= 0x700
 	ZEND_ME(Imagick, identifyImageType, arginfo_class_Imagick_identifyImageType, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GETSETIMAGEMASK
+#if IM_HAVE_IMAGICK_GETSETIMAGEMASK
 	ZEND_ME(Imagick, getImageMask, arginfo_class_Imagick_getImageMask, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GETSETIMAGEMASK
+#if IM_HAVE_IMAGICK_GETSETIMAGEMASK
 	ZEND_ME(Imagick, setImageMask, arginfo_class_Imagick_setImageMask, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x709
+#if MagickLibVersion >= 0x709
 	ZEND_ME(Imagick, cannyEdgeImage, arginfo_class_Imagick_cannyEdgeImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SETSEED
+#if IM_HAVE_IMAGICK_SETSEED
 	ZEND_ME(Imagick, setSeed, arginfo_class_Imagick_setSeed, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_WAVELETDENOISEIMAGE
+#if IM_HAVE_IMAGICK_WAVELETDENOISEIMAGE
 	ZEND_ME(Imagick, waveletDenoiseImage, arginfo_class_Imagick_waveletDenoiseImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_MEANSHIFTIMAGE
+#if IM_HAVE_IMAGICK_MEANSHIFTIMAGE
 	ZEND_ME(Imagick, meanShiftImage, arginfo_class_Imagick_meanShiftImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_KMEANSIMAGE
+#if IM_HAVE_IMAGICK_KMEANSIMAGE
 	ZEND_ME(Imagick, kmeansImage, arginfo_class_Imagick_kmeansImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_RANGETHRESHOLDIMAGE
+#if IM_HAVE_IMAGICK_RANGETHRESHOLDIMAGE
 	ZEND_ME(Imagick, rangeThresholdImage, arginfo_class_Imagick_rangeThresholdImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_AUTOTHRESHOLDIMAGE
+#if IM_HAVE_IMAGICK_AUTOTHRESHOLDIMAGE
 	ZEND_ME(Imagick, autoThresholdImage, arginfo_class_Imagick_autoThresholdImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_BILATERALBLURIMAGE
+#if IM_HAVE_IMAGICK_BILATERALBLURIMAGE
 	ZEND_ME(Imagick, bilateralBlurImage, arginfo_class_Imagick_bilateralBlurImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_CLAHEIMAGE
+#if IM_HAVE_IMAGICK_CLAHEIMAGE
 	ZEND_ME(Imagick, claheImage, arginfo_class_Imagick_claheImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_CHANNELFXIMAGE
+#if IM_HAVE_IMAGICK_CHANNELFXIMAGE
 	ZEND_ME(Imagick, channelFxImage, arginfo_class_Imagick_channelFxImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_COLORTHRESHOLDIMAGE
+#if IM_HAVE_IMAGICK_COLORTHRESHOLDIMAGE
 	ZEND_ME(Imagick, colorThresholdImage, arginfo_class_Imagick_colorThresholdImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_COMPLEXIMAGES
+#if IM_HAVE_IMAGICK_COMPLEXIMAGES
 	ZEND_ME(Imagick, complexImages, arginfo_class_Imagick_complexImages, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_INTERPOLATIVERESIZEIMAGE
+#if IM_HAVE_IMAGICK_INTERPOLATIVERESIZEIMAGE
 	ZEND_ME(Imagick, interpolativeResizeImage, arginfo_class_Imagick_interpolativeResizeImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_LEVELIMAGECOLORS
+#if IM_HAVE_IMAGICK_LEVELIMAGECOLORS
 	ZEND_ME(Imagick, levelImageColors, arginfo_class_Imagick_levelImageColors, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_LEVELIZEIMAGE
+#if IM_HAVE_IMAGICK_LEVELIZEIMAGE
 	ZEND_ME(Imagick, levelizeImage, arginfo_class_Imagick_levelizeImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_ORDEREDDITHERIMAGE
+#if IM_HAVE_IMAGICK_ORDEREDDITHERIMAGE
 	ZEND_ME(Imagick, orderedDitherImage, arginfo_class_Imagick_orderedDitherImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_WHITEBALANCEIMAGE
+#if IM_HAVE_IMAGICK_WHITEBALANCEIMAGE
 	ZEND_ME(Imagick, whiteBalanceImage, arginfo_class_Imagick_whiteBalanceImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_DELETE_OPTION
+#if IM_HAVE_IMAGICK_DELETE_OPTION
 	ZEND_ME(Imagick, deleteOption, arginfo_class_Imagick_deleteOption, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_BACKGROUND_COLOR
+#if IM_HAVE_IMAGICK_GET_BACKGROUND_COLOR
 	ZEND_ME(Imagick, getBackgroundColor, arginfo_class_Imagick_getBackgroundColor, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_ARTIFACTS
+#if IM_HAVE_IMAGICK_GET_IMAGE_ARTIFACTS
 	ZEND_ME(Imagick, getImageArtifacts, arginfo_class_Imagick_getImageArtifacts, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_KURTOSIS
+#if IM_HAVE_IMAGICK_GET_IMAGE_KURTOSIS
 	ZEND_ME(Imagick, getImageKurtosis, arginfo_class_Imagick_getImageKurtosis, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_MEAN
+#if IM_HAVE_IMAGICK_GET_IMAGE_MEAN
 	ZEND_ME(Imagick, getImageMean, arginfo_class_Imagick_getImageMean, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_RANGE
+#if IM_HAVE_IMAGICK_GET_IMAGE_RANGE
 	ZEND_ME(Imagick, getImageRange, arginfo_class_Imagick_getImageRange, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_INTERPOLATE_METHOD
+#if IM_HAVE_IMAGICK_GET_INTERPOLATE_METHOD
 	ZEND_ME(Imagick, getInterpolateMethod, arginfo_class_Imagick_getInterpolateMethod, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_OPTIONS
+#if IM_HAVE_IMAGICK_GET_OPTIONS
 	ZEND_ME(Imagick, getOptions, arginfo_class_Imagick_getOptions, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_ORIENTATION
+#if IM_HAVE_IMAGICK_GET_ORIENTATION
 	ZEND_ME(Imagick, getOrientation, arginfo_class_Imagick_getOrientation, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_RESOLUTION
+#if IM_HAVE_IMAGICK_GET_RESOLUTION
 	ZEND_ME(Imagick, getResolution, arginfo_class_Imagick_getResolution, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_TYPE
+#if IM_HAVE_IMAGICK_GET_TYPE
 	ZEND_ME(Imagick, getType, arginfo_class_Imagick_getType, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_POLYNOMIAL_IMAGE
+#if IM_HAVE_IMAGICK_POLYNOMIAL_IMAGE
 	ZEND_ME(Imagick, polynomialImage, arginfo_class_Imagick_polynomialImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_DEPTH
+#if IM_HAVE_IMAGICK_SET_DEPTH
 	ZEND_ME(Imagick, setDepth, arginfo_class_Imagick_setDepth, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_EXTRACT
+#if IM_HAVE_IMAGICK_SET_EXTRACT
 	ZEND_ME(Imagick, setExtract, arginfo_class_Imagick_setExtract, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_INTERPOLATE_METHOD
+#if IM_HAVE_IMAGICK_SET_INTERPOLATE_METHOD
 	ZEND_ME(Imagick, setInterpolateMethod, arginfo_class_Imagick_setInterpolateMethod, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_ORIENTATION
+#if IM_HAVE_IMAGICK_SET_ORIENTATION
 	ZEND_ME(Imagick, setOrientation, arginfo_class_Imagick_setOrientation, ZEND_ACC_PUBLIC)
 #endif
 	ZEND_FE_END
 };
-#endif

--- a/Imagick_arginfo.h
+++ b/Imagick_arginfo.h
@@ -849,24 +849,6 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_clutImage, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x635 && MagickLibVersion >= 0x700
-
-#if PHP_VERSION_ID >= 80000
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_clutImageWithInterpolate, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_clutImageWithInterpolate, 0, 0, 2)
-#endif
-
-	ZEND_ARG_OBJ_INFO(0, lookup_table, Imagick, 0)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, pixel_interpolate_method, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, pixel_interpolate_method)
-#endif
-ZEND_END_ARG_INFO()
-#endif
-
 #if MagickLibVersion > 0x635
 
 #if PHP_VERSION_ID >= 80000
@@ -4533,6 +4515,36 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageBiasQuantum, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
+#if MagickLibVersion >= 0x700
+
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageBluePrimary, 0, 3, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageBluePrimary, 0, 0, 3)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, x, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, x)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, y, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, y)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, z, IS_DOUBLE, 0)
+#else
+    ZEND_ARG_INFO(0, z)
+#endif
+ZEND_END_ARG_INFO()
+#endif
+
+#if !(MagickLibVersion >= 0x700)
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageBluePrimary, 0, 2, _IS_BOOL, 0)
@@ -4553,6 +4565,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageBluePrimary, 0, 0, 2)
     ZEND_ARG_INFO(0, y)
 #endif
 ZEND_END_ARG_INFO()
+#endif
 
 
 #if PHP_VERSION_ID >= 80000
@@ -4633,7 +4646,13 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_setImageExtent arginfo_class_Imagick_sampleImage
 
+#if MagickLibVersion >= 0x700
 #define arginfo_class_Imagick_setImageGreenPrimary arginfo_class_Imagick_setImageBluePrimary
+#endif
+
+#if !(MagickLibVersion >= 0x700)
+#define arginfo_class_Imagick_setImageGreenPrimary arginfo_class_Imagick_setImageBluePrimary
+#endif
 
 
 #if PHP_VERSION_ID >= 80000
@@ -4671,7 +4690,13 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageProfile, 0, 0, 2)
 #endif
 ZEND_END_ARG_INFO()
 
+#if MagickLibVersion >= 0x700
 #define arginfo_class_Imagick_setImageRedPrimary arginfo_class_Imagick_setImageBluePrimary
+#endif
+
+#if !(MagickLibVersion >= 0x700)
+#define arginfo_class_Imagick_setImageRedPrimary arginfo_class_Imagick_setImageBluePrimary
+#endif
 
 
 #if PHP_VERSION_ID >= 80000
@@ -4703,7 +4728,13 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageVirtualPixelMethod, 0, 0, 1
 #endif
 ZEND_END_ARG_INFO()
 
+#if MagickLibVersion >= 0x700
 #define arginfo_class_Imagick_setImageWhitePoint arginfo_class_Imagick_setImageBluePrimary
+#endif
+
+#if !(MagickLibVersion >= 0x700)
+#define arginfo_class_Imagick_setImageWhitePoint arginfo_class_Imagick_setImageBluePrimary
+#endif
 
 
 #if PHP_VERSION_ID >= 80000
@@ -5048,16 +5079,37 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_Imagick_key arginfo_class_Imagick_getSizeOffset
 #endif
 
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_next, 0, 0, IS_VOID, 0)
+#if MagickLibVersion > 0x628
+
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_next, 0, 0, IS_VOID, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_next, 0, 0, 0)
+#endif
+
 ZEND_END_ARG_INFO()
+#endif
 
+#if MagickLibVersion > 0x628
 #define arginfo_class_Imagick_rewind arginfo_class_Imagick_next
+#endif
 
-#define arginfo_class_Imagick_valid arginfo_class_Imagick_removeImage
+#if MagickLibVersion > 0x628
+#define arginfo_class_Imagick_valid arginfo_class_Imagick_optimizeImageLayers
+#endif
 
-#define arginfo_class_Imagick_current arginfo_class_Imagick_clone
+#if MagickLibVersion > 0x628
 
-#if MagickLibVersion >= 0x659
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_current, 0, 0, Imagick, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_current, 0, 0, 0)
+#endif
+
+ZEND_END_ARG_INFO()
+#endif
+
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x659
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_brightnessContrastImage, 0, 2, _IS_BOOL, 0)
@@ -5081,7 +5133,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_brightnessContrastImage, 0, 0, 2)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x661
+#if MagickLibVersion > 0x628 && MagickLibVersion > 0x661
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_colorMatrixImage, 0, 1, _IS_BOOL, 0)
@@ -5098,6 +5150,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_colorMatrixImage, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
+#if MagickLibVersion > 0x628
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_selectiveBlurImage, 0, 3, _IS_BOOL, 0)
@@ -5125,8 +5178,9 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_selectiveBlurImage, 0, 0, 3)
 #endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
+#endif
 
-#if MagickLibVersion >= 0x689
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x689
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_rotationalBlurImage, 0, 1, _IS_BOOL, 0)
@@ -5144,7 +5198,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_rotationalBlurImage, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion >= 0x683
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x683
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_statisticImage, 0, 3, _IS_BOOL, 0)
@@ -5174,7 +5228,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_statisticImage, 0, 0, 3)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion >= 0x652
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x652
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_subimageMatch, 0, 1, Imagick, 0)
@@ -5208,17 +5262,62 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_subimageMatch, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion >= 0x652
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x652
 #define arginfo_class_Imagick_similarityImage arginfo_class_Imagick_subimageMatch
 #endif
 
-#define arginfo_class_Imagick_setRegistry arginfo_class_Imagick_setOption
+#if MagickLibVersion > 0x628
 
-#define arginfo_class_Imagick_getRegistry arginfo_class_Imagick_getOption
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setRegistry, 0, 2, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setRegistry, 0, 0, 2)
+#endif
 
-#define arginfo_class_Imagick_listRegistry arginfo_class_Imagick_getImageGeometry
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, key)
+#endif
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, value)
+#endif
+ZEND_END_ARG_INFO()
+#endif
 
-#if MagickLibVersion >= 0x680
+#if MagickLibVersion > 0x628
+
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getRegistry, 0, 1, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getRegistry, 0, 0, 1)
+#endif
+
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+#else
+    ZEND_ARG_INFO(0, key)
+#endif
+ZEND_END_ARG_INFO()
+#endif
+
+#if MagickLibVersion > 0x628
+
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_listRegistry, 0, 0, IS_ARRAY, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_listRegistry, 0, 0, 0)
+#endif
+
+ZEND_END_ARG_INFO()
+#endif
+
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x680
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_morphology, 0, 3, _IS_BOOL, 0)
@@ -5243,7 +5342,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_morphology, 0, 0, 3)
 ZEND_END_ARG_INFO()
 #endif
 
-#if defined(IMAGICK_WITH_KERNEL) && MagickLibVersion < 0x700
+#if MagickLibVersion > 0x628 && defined(IMAGICK_WITH_KERNEL) && MagickLibVersion < 0x700
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_filter, 0, 1, _IS_BOOL, 0)
@@ -5256,6 +5355,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_filter, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
+#if MagickLibVersion > 0x628
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setAntialias, 0, 1, IS_VOID, 0)
@@ -5270,10 +5370,13 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setAntialias, 0, 0, 1)
     ZEND_ARG_INFO(0, antialias)
 #endif
 ZEND_END_ARG_INFO()
+#endif
 
-#define arginfo_class_Imagick_getAntialias arginfo_class_Imagick_removeImage
+#if MagickLibVersion > 0x628
+#define arginfo_class_Imagick_getAntialias arginfo_class_Imagick_optimizeImageLayers
+#endif
 
-#if MagickLibVersion > 0x676
+#if MagickLibVersion > 0x628 && MagickLibVersion > 0x676
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_colorDecisionListImage, 0, 1, _IS_BOOL, 0)
@@ -5290,7 +5393,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_colorDecisionListImage, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion >= 0x687
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x687
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_optimizeImageTransparency, 0, 0, IS_VOID, 0)
@@ -5301,7 +5404,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_optimizeImageTransparency, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion >= 0x660
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x660
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_autoGammaImage, 0, 0, IS_VOID, 0)
@@ -5313,7 +5416,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_autoGammaImage, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion >= 0x692
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_autoOrient, 0, 0, IS_VOID, 0)
@@ -5324,11 +5427,11 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_autoOrient, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion >= 0x692
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
 #define arginfo_class_Imagick_autoOrientate arginfo_class_Imagick_autoOrient
 #endif
 
-#if MagickLibVersion >= 0x692
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_compositeImageGravity, 0, 3, _IS_BOOL, 0)
@@ -5352,7 +5455,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_compositeImageGravity, 0, 0, 3)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion >= 0x693
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x693
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_localContrastImage, 0, 2, IS_VOID, 0)
@@ -5375,7 +5478,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_localContrastImage, 0, 0, 2)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion >= 0x700
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x700
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_identifyImageType, 0, 0, IS_LONG, 0)
@@ -5386,7 +5489,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_identifyImageType, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_GETSETIMAGEMASK
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GETSETIMAGEMASK
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getImageMask, 0, 1, Imagick, 1)
@@ -5403,7 +5506,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageMask, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_GETSETIMAGEMASK
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GETSETIMAGEMASK
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageMask, 0, 2, IS_VOID, 0)
@@ -5421,7 +5524,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageMask, 0, 0, 2)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion >= 0x709
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x709
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_cannyEdgeImage, 0, 4, _IS_BOOL, 0)
@@ -5456,7 +5559,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_cannyEdgeImage, 0, 0, 4)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_SETSEED
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SETSEED
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setSeed, 0, 1, IS_VOID, 0)
@@ -5473,7 +5576,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setSeed, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_WAVELETDENOISEIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_WAVELETDENOISEIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_waveletDenoiseImage, 0, 2, _IS_BOOL, 0)
@@ -5496,7 +5599,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_waveletDenoiseImage, 0, 0, 2)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_MEANSHIFTIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_MEANSHIFTIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_meanShiftImage, 0, 3, _IS_BOOL, 0)
@@ -5525,7 +5628,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_meanShiftImage, 0, 0, 3)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_KMEANSIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_KMEANSIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_kmeansImage, 0, 3, _IS_BOOL, 0)
@@ -5554,7 +5657,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_kmeansImage, 0, 0, 3)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_RANGETHRESHOLDIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_RANGETHRESHOLDIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_rangeThresholdImage, 0, 4, _IS_BOOL, 0)
@@ -5589,7 +5692,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_rangeThresholdImage, 0, 0, 4)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_AUTOTHRESHOLDIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_AUTOTHRESHOLDIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_autoThresholdImage, 0, 1, _IS_BOOL, 0)
@@ -5606,7 +5709,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_autoThresholdImage, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_BILATERALBLURIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_BILATERALBLURIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_bilateralBlurImage, 0, 4, _IS_BOOL, 0)
@@ -5641,7 +5744,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_bilateralBlurImage, 0, 0, 4)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_CLAHEIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_CLAHEIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_claheImage, 0, 4, _IS_BOOL, 0)
@@ -5676,7 +5779,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_claheImage, 0, 0, 4)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_CHANNELFXIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_CHANNELFXIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_channelFxImage, 0, 1, Imagick, 0)
@@ -5693,7 +5796,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_channelFxImage, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_COLORTHRESHOLDIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_COLORTHRESHOLDIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_colorThresholdImage, 0, 2, _IS_BOOL, 0)
@@ -5706,7 +5809,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_colorThresholdImage, 0, 0, 2)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_COMPLEXIMAGES
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_COMPLEXIMAGES
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_complexImages, 0, 1, Imagick, 0)
@@ -5723,7 +5826,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_complexImages, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_INTERPOLATIVERESIZEIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_INTERPOLATIVERESIZEIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_interpolativeResizeImage, 0, 3, _IS_BOOL, 0)
@@ -5752,7 +5855,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_interpolativeResizeImage, 0, 0, 3)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_LEVELIMAGECOLORS
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_LEVELIMAGECOLORS
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_levelImageColors, 0, 3, _IS_BOOL, 0)
@@ -5771,7 +5874,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_levelImageColors, 0, 0, 3)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_LEVELIZEIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_LEVELIZEIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_levelizeImage, 0, 3, _IS_BOOL, 0)
@@ -5800,7 +5903,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_levelizeImage, 0, 0, 3)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_ORDEREDDITHERIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_ORDEREDDITHERIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_orderedDitherImage, 0, 1, _IS_BOOL, 0)
@@ -5817,7 +5920,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_orderedDitherImage, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_WHITEBALANCEIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_WHITEBALANCEIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_whiteBalanceImage, 0, 0, _IS_BOOL, 0)
@@ -5828,7 +5931,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_whiteBalanceImage, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_DELETE_OPTION
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_DELETE_OPTION
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_deleteOption, 0, 1, _IS_BOOL, 0)
@@ -5845,7 +5948,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_deleteOption, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_GET_BACKGROUND_COLOR
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_BACKGROUND_COLOR
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getBackgroundColor, 0, 0, ImagickPixel, 0)
@@ -5856,7 +5959,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getBackgroundColor, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_GET_IMAGE_ARTIFACTS
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_ARTIFACTS
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageArtifacts, 0, 0, IS_ARRAY, 0)
@@ -5868,7 +5971,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageArtifacts, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_GET_IMAGE_KURTOSIS
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_KURTOSIS
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageKurtosis, 0, 0, IS_ARRAY, 0)
@@ -5879,7 +5982,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageKurtosis, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_GET_IMAGE_MEAN
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_MEAN
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageMean, 0, 0, IS_ARRAY, 0)
@@ -5890,7 +5993,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageMean, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_GET_IMAGE_RANGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_RANGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageRange, 0, 0, IS_ARRAY, 0)
@@ -5901,7 +6004,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageRange, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_GET_INTERPOLATE_METHOD
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_INTERPOLATE_METHOD
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getInterpolateMethod, 0, 0, IS_LONG, 0)
@@ -5912,7 +6015,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getInterpolateMethod, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_GET_OPTIONS
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_OPTIONS
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getOptions, 0, 0, IS_ARRAY, 0)
@@ -5924,7 +6027,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getOptions, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_GET_ORIENTATION
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_ORIENTATION
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getOrientation, 0, 0, IS_LONG, 0)
@@ -5935,7 +6038,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getOrientation, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_GET_RESOLUTION
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_RESOLUTION
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getResolution, 0, 0, IS_ARRAY, 0)
@@ -5946,7 +6049,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getResolution, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_GET_TYPE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_TYPE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getType, 0, 0, IS_LONG, 0)
@@ -5957,7 +6060,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getType, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_POLYNOMIAL_IMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_POLYNOMIAL_IMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_polynomialImage, 0, 1, _IS_BOOL, 0)
@@ -5974,7 +6077,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_polynomialImage, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_SET_DEPTH
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_DEPTH
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setDepth, 0, 1, _IS_BOOL, 0)
@@ -5991,7 +6094,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setDepth, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_SET_EXTRACT
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_EXTRACT
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setExtract, 0, 1, _IS_BOOL, 0)
@@ -6008,7 +6111,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setExtract, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_SET_INTERPOLATE_METHOD
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_INTERPOLATE_METHOD
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setInterpolateMethod, 0, 1, _IS_BOOL, 0)
@@ -6025,7 +6128,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setInterpolateMethod, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if IM_HAVE_IMAGICK_SET_ORIENTATION
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_ORIENTATION
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setOrientation, 0, 1, _IS_BOOL, 0)
@@ -6174,9 +6277,6 @@ ZEND_METHOD(Imagick, paintFloodfillImage);
 #endif
 #if MagickLibVersion > 0x635
 ZEND_METHOD(Imagick, clutImage);
-#endif
-#if MagickLibVersion > 0x635 && MagickLibVersion >= 0x700
-ZEND_METHOD(Imagick, clutImageWithInterpolate);
 #endif
 #if MagickLibVersion > 0x635
 ZEND_METHOD(Imagick, getImageProperties);
@@ -6595,20 +6695,40 @@ ZEND_METHOD(Imagick, setImageBias);
 #if MagickLibVersion < 0x700
 ZEND_METHOD(Imagick, setImageBiasQuantum);
 #endif
+#if MagickLibVersion >= 0x700
 ZEND_METHOD(Imagick, setImageBluePrimary);
+#endif
+#if !(MagickLibVersion >= 0x700)
+ZEND_METHOD(Imagick, setImageBluePrimary);
+#endif
 ZEND_METHOD(Imagick, setImageBorderColor);
 ZEND_METHOD(Imagick, setImageChannelDepth);
 ZEND_METHOD(Imagick, setImageColormapColor);
 ZEND_METHOD(Imagick, setImageColorspace);
 ZEND_METHOD(Imagick, setImageDispose);
 ZEND_METHOD(Imagick, setImageExtent);
+#if MagickLibVersion >= 0x700
 ZEND_METHOD(Imagick, setImageGreenPrimary);
+#endif
+#if !(MagickLibVersion >= 0x700)
+ZEND_METHOD(Imagick, setImageGreenPrimary);
+#endif
 ZEND_METHOD(Imagick, setImageInterlaceScheme);
 ZEND_METHOD(Imagick, setImageProfile);
+#if MagickLibVersion >= 0x700
 ZEND_METHOD(Imagick, setImageRedPrimary);
+#endif
+#if !(MagickLibVersion >= 0x700)
+ZEND_METHOD(Imagick, setImageRedPrimary);
+#endif
 ZEND_METHOD(Imagick, setImageRenderingIntent);
 ZEND_METHOD(Imagick, setImageVirtualPixelMethod);
+#if MagickLibVersion >= 0x700
 ZEND_METHOD(Imagick, setImageWhitePoint);
+#endif
+#if !(MagickLibVersion >= 0x700)
+ZEND_METHOD(Imagick, setImageWhitePoint);
+#endif
 ZEND_METHOD(Imagick, sigmoidalContrastImage);
 ZEND_METHOD(Imagick, stereoImage);
 ZEND_METHOD(Imagick, textureImage);
@@ -6656,159 +6776,181 @@ ZEND_METHOD(Imagick, setResolution);
 ZEND_METHOD(Imagick, setSamplingFactors);
 ZEND_METHOD(Imagick, setSize);
 ZEND_METHOD(Imagick, setType);
+#if MagickLibVersion > 0x628
+ZEND_METHOD(Imagick, nextImage);
+#endif
+#if MagickLibVersion > 0x628
+ZEND_METHOD(Imagick, setFirstIterator);
+#endif
+#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, valid);
+#endif
+#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, current);
-#if MagickLibVersion >= 0x659
+#endif
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x659
 ZEND_METHOD(Imagick, brightnessContrastImage);
 #endif
-#if MagickLibVersion > 0x661
+#if MagickLibVersion > 0x628 && MagickLibVersion > 0x661
 ZEND_METHOD(Imagick, colorMatrixImage);
 #endif
+#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, selectiveBlurImage);
-#if MagickLibVersion >= 0x689
+#endif
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x689
 ZEND_METHOD(Imagick, rotationalBlurImage);
 #endif
-#if MagickLibVersion >= 0x683
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x683
 ZEND_METHOD(Imagick, statisticImage);
 #endif
-#if MagickLibVersion >= 0x652
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x652
 ZEND_METHOD(Imagick, subimageMatch);
 #endif
+#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, setRegistry);
+#endif
+#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, getRegistry);
+#endif
+#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, listRegistry);
-#if MagickLibVersion >= 0x680
+#endif
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x680
 ZEND_METHOD(Imagick, morphology);
 #endif
-#if defined(IMAGICK_WITH_KERNEL) && MagickLibVersion < 0x700
+#if MagickLibVersion > 0x628 && defined(IMAGICK_WITH_KERNEL) && MagickLibVersion < 0x700
 ZEND_METHOD(Imagick, filter);
 #endif
+#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, setAntialias);
+#endif
+#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, getAntialias);
-#if MagickLibVersion > 0x676
+#endif
+#if MagickLibVersion > 0x628 && MagickLibVersion > 0x676
 ZEND_METHOD(Imagick, colorDecisionListImage);
 #endif
-#if MagickLibVersion >= 0x687
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x687
 ZEND_METHOD(Imagick, optimizeImageTransparency);
 #endif
-#if MagickLibVersion >= 0x660
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x660
 ZEND_METHOD(Imagick, autoGammaImage);
 #endif
-#if MagickLibVersion >= 0x692
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
 ZEND_METHOD(Imagick, autoOrient);
 #endif
-#if MagickLibVersion >= 0x692
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
 ZEND_METHOD(Imagick, compositeImageGravity);
 #endif
-#if MagickLibVersion >= 0x693
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x693
 ZEND_METHOD(Imagick, localContrastImage);
 #endif
-#if MagickLibVersion >= 0x700
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x700
 ZEND_METHOD(Imagick, identifyImageType);
 #endif
-#if IM_HAVE_IMAGICK_GETSETIMAGEMASK
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GETSETIMAGEMASK
 ZEND_METHOD(Imagick, getImageMask);
 #endif
-#if IM_HAVE_IMAGICK_GETSETIMAGEMASK
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GETSETIMAGEMASK
 ZEND_METHOD(Imagick, setImageMask);
 #endif
-#if MagickLibVersion >= 0x709
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x709
 ZEND_METHOD(Imagick, cannyEdgeImage);
 #endif
-#if IM_HAVE_IMAGICK_SETSEED
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SETSEED
 ZEND_METHOD(Imagick, setSeed);
 #endif
-#if IM_HAVE_IMAGICK_WAVELETDENOISEIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_WAVELETDENOISEIMAGE
 ZEND_METHOD(Imagick, waveletDenoiseImage);
 #endif
-#if IM_HAVE_IMAGICK_MEANSHIFTIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_MEANSHIFTIMAGE
 ZEND_METHOD(Imagick, meanShiftImage);
 #endif
-#if IM_HAVE_IMAGICK_KMEANSIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_KMEANSIMAGE
 ZEND_METHOD(Imagick, kmeansImage);
 #endif
-#if IM_HAVE_IMAGICK_RANGETHRESHOLDIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_RANGETHRESHOLDIMAGE
 ZEND_METHOD(Imagick, rangeThresholdImage);
 #endif
-#if IM_HAVE_IMAGICK_AUTOTHRESHOLDIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_AUTOTHRESHOLDIMAGE
 ZEND_METHOD(Imagick, autoThresholdImage);
 #endif
-#if IM_HAVE_IMAGICK_BILATERALBLURIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_BILATERALBLURIMAGE
 ZEND_METHOD(Imagick, bilateralBlurImage);
 #endif
-#if IM_HAVE_IMAGICK_CLAHEIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_CLAHEIMAGE
 ZEND_METHOD(Imagick, claheImage);
 #endif
-#if IM_HAVE_IMAGICK_CHANNELFXIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_CHANNELFXIMAGE
 ZEND_METHOD(Imagick, channelFxImage);
 #endif
-#if IM_HAVE_IMAGICK_COLORTHRESHOLDIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_COLORTHRESHOLDIMAGE
 ZEND_METHOD(Imagick, colorThresholdImage);
 #endif
-#if IM_HAVE_IMAGICK_COMPLEXIMAGES
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_COMPLEXIMAGES
 ZEND_METHOD(Imagick, complexImages);
 #endif
-#if IM_HAVE_IMAGICK_INTERPOLATIVERESIZEIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_INTERPOLATIVERESIZEIMAGE
 ZEND_METHOD(Imagick, interpolativeResizeImage);
 #endif
-#if IM_HAVE_IMAGICK_LEVELIMAGECOLORS
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_LEVELIMAGECOLORS
 ZEND_METHOD(Imagick, levelImageColors);
 #endif
-#if IM_HAVE_IMAGICK_LEVELIZEIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_LEVELIZEIMAGE
 ZEND_METHOD(Imagick, levelizeImage);
 #endif
-#if IM_HAVE_IMAGICK_ORDEREDDITHERIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_ORDEREDDITHERIMAGE
 ZEND_METHOD(Imagick, orderedDitherImage);
 #endif
-#if IM_HAVE_IMAGICK_WHITEBALANCEIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_WHITEBALANCEIMAGE
 ZEND_METHOD(Imagick, whiteBalanceImage);
 #endif
-#if IM_HAVE_IMAGICK_DELETE_OPTION
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_DELETE_OPTION
 ZEND_METHOD(Imagick, deleteOption);
 #endif
-#if IM_HAVE_IMAGICK_GET_BACKGROUND_COLOR
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_BACKGROUND_COLOR
 ZEND_METHOD(Imagick, getBackgroundColor);
 #endif
-#if IM_HAVE_IMAGICK_GET_IMAGE_ARTIFACTS
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_ARTIFACTS
 ZEND_METHOD(Imagick, getImageArtifacts);
 #endif
-#if IM_HAVE_IMAGICK_GET_IMAGE_KURTOSIS
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_KURTOSIS
 ZEND_METHOD(Imagick, getImageKurtosis);
 #endif
-#if IM_HAVE_IMAGICK_GET_IMAGE_MEAN
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_MEAN
 ZEND_METHOD(Imagick, getImageMean);
 #endif
-#if IM_HAVE_IMAGICK_GET_IMAGE_RANGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_RANGE
 ZEND_METHOD(Imagick, getImageRange);
 #endif
-#if IM_HAVE_IMAGICK_GET_INTERPOLATE_METHOD
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_INTERPOLATE_METHOD
 ZEND_METHOD(Imagick, getInterpolateMethod);
 #endif
-#if IM_HAVE_IMAGICK_GET_OPTIONS
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_OPTIONS
 ZEND_METHOD(Imagick, getOptions);
 #endif
-#if IM_HAVE_IMAGICK_GET_ORIENTATION
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_ORIENTATION
 ZEND_METHOD(Imagick, getOrientation);
 #endif
-#if IM_HAVE_IMAGICK_GET_RESOLUTION
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_RESOLUTION
 ZEND_METHOD(Imagick, getResolution);
 #endif
-#if IM_HAVE_IMAGICK_GET_TYPE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_TYPE
 ZEND_METHOD(Imagick, getType);
 #endif
-#if IM_HAVE_IMAGICK_POLYNOMIAL_IMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_POLYNOMIAL_IMAGE
 ZEND_METHOD(Imagick, polynomialImage);
 #endif
-#if IM_HAVE_IMAGICK_SET_DEPTH
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_DEPTH
 ZEND_METHOD(Imagick, setDepth);
 #endif
-#if IM_HAVE_IMAGICK_SET_EXTRACT
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_EXTRACT
 ZEND_METHOD(Imagick, setExtract);
 #endif
-#if IM_HAVE_IMAGICK_SET_INTERPOLATE_METHOD
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_INTERPOLATE_METHOD
 ZEND_METHOD(Imagick, setInterpolateMethod);
 #endif
-#if IM_HAVE_IMAGICK_SET_ORIENTATION
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_ORIENTATION
 ZEND_METHOD(Imagick, setOrientation);
 #endif
 
@@ -6948,9 +7090,6 @@ static const zend_function_entry class_Imagick_methods[] = {
 #endif
 #if MagickLibVersion > 0x635
 	ZEND_ME(Imagick, clutImage, arginfo_class_Imagick_clutImage, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x635 && MagickLibVersion >= 0x700
-	ZEND_ME(Imagick, clutImageWithInterpolate, arginfo_class_Imagick_clutImageWithInterpolate, ZEND_ACC_PUBLIC)
 #endif
 #if MagickLibVersion > 0x635
 	ZEND_ME(Imagick, getImageProperties, arginfo_class_Imagick_getImageProperties, ZEND_ACC_PUBLIC)
@@ -7371,20 +7510,40 @@ static const zend_function_entry class_Imagick_methods[] = {
 #if MagickLibVersion < 0x700
 	ZEND_ME(Imagick, setImageBiasQuantum, arginfo_class_Imagick_setImageBiasQuantum, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
 #endif
+#if MagickLibVersion >= 0x700
 	ZEND_ME(Imagick, setImageBluePrimary, arginfo_class_Imagick_setImageBluePrimary, ZEND_ACC_PUBLIC)
+#endif
+#if !(MagickLibVersion >= 0x700)
+	ZEND_ME(Imagick, setImageBluePrimary, arginfo_class_Imagick_setImageBluePrimary, ZEND_ACC_PUBLIC)
+#endif
 	ZEND_ME(Imagick, setImageBorderColor, arginfo_class_Imagick_setImageBorderColor, ZEND_ACC_PUBLIC)
 	ZEND_ME(Imagick, setImageChannelDepth, arginfo_class_Imagick_setImageChannelDepth, ZEND_ACC_PUBLIC)
 	ZEND_ME(Imagick, setImageColormapColor, arginfo_class_Imagick_setImageColormapColor, ZEND_ACC_PUBLIC)
 	ZEND_ME(Imagick, setImageColorspace, arginfo_class_Imagick_setImageColorspace, ZEND_ACC_PUBLIC)
 	ZEND_ME(Imagick, setImageDispose, arginfo_class_Imagick_setImageDispose, ZEND_ACC_PUBLIC)
 	ZEND_ME(Imagick, setImageExtent, arginfo_class_Imagick_setImageExtent, ZEND_ACC_PUBLIC)
+#if MagickLibVersion >= 0x700
 	ZEND_ME(Imagick, setImageGreenPrimary, arginfo_class_Imagick_setImageGreenPrimary, ZEND_ACC_PUBLIC)
+#endif
+#if !(MagickLibVersion >= 0x700)
+	ZEND_ME(Imagick, setImageGreenPrimary, arginfo_class_Imagick_setImageGreenPrimary, ZEND_ACC_PUBLIC)
+#endif
 	ZEND_ME(Imagick, setImageInterlaceScheme, arginfo_class_Imagick_setImageInterlaceScheme, ZEND_ACC_PUBLIC)
 	ZEND_ME(Imagick, setImageProfile, arginfo_class_Imagick_setImageProfile, ZEND_ACC_PUBLIC)
+#if MagickLibVersion >= 0x700
 	ZEND_ME(Imagick, setImageRedPrimary, arginfo_class_Imagick_setImageRedPrimary, ZEND_ACC_PUBLIC)
+#endif
+#if !(MagickLibVersion >= 0x700)
+	ZEND_ME(Imagick, setImageRedPrimary, arginfo_class_Imagick_setImageRedPrimary, ZEND_ACC_PUBLIC)
+#endif
 	ZEND_ME(Imagick, setImageRenderingIntent, arginfo_class_Imagick_setImageRenderingIntent, ZEND_ACC_PUBLIC)
 	ZEND_ME(Imagick, setImageVirtualPixelMethod, arginfo_class_Imagick_setImageVirtualPixelMethod, ZEND_ACC_PUBLIC)
+#if MagickLibVersion >= 0x700
 	ZEND_ME(Imagick, setImageWhitePoint, arginfo_class_Imagick_setImageWhitePoint, ZEND_ACC_PUBLIC)
+#endif
+#if !(MagickLibVersion >= 0x700)
+	ZEND_ME(Imagick, setImageWhitePoint, arginfo_class_Imagick_setImageWhitePoint, ZEND_ACC_PUBLIC)
+#endif
 	ZEND_ME(Imagick, sigmoidalContrastImage, arginfo_class_Imagick_sigmoidalContrastImage, ZEND_ACC_PUBLIC)
 	ZEND_ME(Imagick, stereoImage, arginfo_class_Imagick_stereoImage, ZEND_ACC_PUBLIC)
 	ZEND_ME(Imagick, textureImage, arginfo_class_Imagick_textureImage, ZEND_ACC_PUBLIC)
@@ -7435,167 +7594,187 @@ static const zend_function_entry class_Imagick_methods[] = {
 #if MagickLibVersion > 0x628
 	ZEND_MALIAS(Imagick, key, getIteratorIndex, arginfo_class_Imagick_key, ZEND_ACC_PUBLIC)
 #endif
+#if MagickLibVersion > 0x628
 	ZEND_MALIAS(Imagick, next, nextImage, arginfo_class_Imagick_next, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_MALIAS(Imagick, rewind, setFirstIterator, arginfo_class_Imagick_rewind, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, valid, arginfo_class_Imagick_valid, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, current, arginfo_class_Imagick_current, ZEND_ACC_PUBLIC)
-#if MagickLibVersion >= 0x659
+#endif
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x659
 	ZEND_ME(Imagick, brightnessContrastImage, arginfo_class_Imagick_brightnessContrastImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x661
+#if MagickLibVersion > 0x628 && MagickLibVersion > 0x661
 	ZEND_ME(Imagick, colorMatrixImage, arginfo_class_Imagick_colorMatrixImage, ZEND_ACC_PUBLIC)
 #endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, selectiveBlurImage, arginfo_class_Imagick_selectiveBlurImage, ZEND_ACC_PUBLIC)
-#if MagickLibVersion >= 0x689
+#endif
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x689
 	ZEND_ME(Imagick, rotationalBlurImage, arginfo_class_Imagick_rotationalBlurImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion >= 0x683
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x683
 	ZEND_ME(Imagick, statisticImage, arginfo_class_Imagick_statisticImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion >= 0x652
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x652
 	ZEND_ME(Imagick, subimageMatch, arginfo_class_Imagick_subimageMatch, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion >= 0x652
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x652
 	ZEND_MALIAS(Imagick, similarityImage, subimageMatch, arginfo_class_Imagick_similarityImage, ZEND_ACC_PUBLIC)
 #endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, setRegistry, arginfo_class_Imagick_setRegistry, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, getRegistry, arginfo_class_Imagick_getRegistry, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, listRegistry, arginfo_class_Imagick_listRegistry, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-#if MagickLibVersion >= 0x680
+#endif
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x680
 	ZEND_ME(Imagick, morphology, arginfo_class_Imagick_morphology, ZEND_ACC_PUBLIC)
 #endif
-#if defined(IMAGICK_WITH_KERNEL) && MagickLibVersion < 0x700
+#if MagickLibVersion > 0x628 && defined(IMAGICK_WITH_KERNEL) && MagickLibVersion < 0x700
 	ZEND_ME(Imagick, filter, arginfo_class_Imagick_filter, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
 #endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, setAntialias, arginfo_class_Imagick_setAntialias, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, getAntialias, arginfo_class_Imagick_getAntialias, ZEND_ACC_PUBLIC)
-#if MagickLibVersion > 0x676
+#endif
+#if MagickLibVersion > 0x628 && MagickLibVersion > 0x676
 	ZEND_ME(Imagick, colorDecisionListImage, arginfo_class_Imagick_colorDecisionListImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion >= 0x687
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x687
 	ZEND_ME(Imagick, optimizeImageTransparency, arginfo_class_Imagick_optimizeImageTransparency, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion >= 0x660
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x660
 	ZEND_ME(Imagick, autoGammaImage, arginfo_class_Imagick_autoGammaImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion >= 0x692
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
 	ZEND_ME(Imagick, autoOrient, arginfo_class_Imagick_autoOrient, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion >= 0x692
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
 	ZEND_MALIAS(Imagick, autoOrientate, autoOrient, arginfo_class_Imagick_autoOrientate, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion >= 0x692
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
 	ZEND_ME(Imagick, compositeImageGravity, arginfo_class_Imagick_compositeImageGravity, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion >= 0x693
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x693
 	ZEND_ME(Imagick, localContrastImage, arginfo_class_Imagick_localContrastImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion >= 0x700
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x700
 	ZEND_ME(Imagick, identifyImageType, arginfo_class_Imagick_identifyImageType, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_GETSETIMAGEMASK
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GETSETIMAGEMASK
 	ZEND_ME(Imagick, getImageMask, arginfo_class_Imagick_getImageMask, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_GETSETIMAGEMASK
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GETSETIMAGEMASK
 	ZEND_ME(Imagick, setImageMask, arginfo_class_Imagick_setImageMask, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion >= 0x709
+#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x709
 	ZEND_ME(Imagick, cannyEdgeImage, arginfo_class_Imagick_cannyEdgeImage, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_SETSEED
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SETSEED
 	ZEND_ME(Imagick, setSeed, arginfo_class_Imagick_setSeed, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 #endif
-#if IM_HAVE_IMAGICK_WAVELETDENOISEIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_WAVELETDENOISEIMAGE
 	ZEND_ME(Imagick, waveletDenoiseImage, arginfo_class_Imagick_waveletDenoiseImage, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_MEANSHIFTIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_MEANSHIFTIMAGE
 	ZEND_ME(Imagick, meanShiftImage, arginfo_class_Imagick_meanShiftImage, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_KMEANSIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_KMEANSIMAGE
 	ZEND_ME(Imagick, kmeansImage, arginfo_class_Imagick_kmeansImage, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_RANGETHRESHOLDIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_RANGETHRESHOLDIMAGE
 	ZEND_ME(Imagick, rangeThresholdImage, arginfo_class_Imagick_rangeThresholdImage, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_AUTOTHRESHOLDIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_AUTOTHRESHOLDIMAGE
 	ZEND_ME(Imagick, autoThresholdImage, arginfo_class_Imagick_autoThresholdImage, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_BILATERALBLURIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_BILATERALBLURIMAGE
 	ZEND_ME(Imagick, bilateralBlurImage, arginfo_class_Imagick_bilateralBlurImage, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_CLAHEIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_CLAHEIMAGE
 	ZEND_ME(Imagick, claheImage, arginfo_class_Imagick_claheImage, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_CHANNELFXIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_CHANNELFXIMAGE
 	ZEND_ME(Imagick, channelFxImage, arginfo_class_Imagick_channelFxImage, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_COLORTHRESHOLDIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_COLORTHRESHOLDIMAGE
 	ZEND_ME(Imagick, colorThresholdImage, arginfo_class_Imagick_colorThresholdImage, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_COMPLEXIMAGES
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_COMPLEXIMAGES
 	ZEND_ME(Imagick, complexImages, arginfo_class_Imagick_complexImages, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_INTERPOLATIVERESIZEIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_INTERPOLATIVERESIZEIMAGE
 	ZEND_ME(Imagick, interpolativeResizeImage, arginfo_class_Imagick_interpolativeResizeImage, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_LEVELIMAGECOLORS
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_LEVELIMAGECOLORS
 	ZEND_ME(Imagick, levelImageColors, arginfo_class_Imagick_levelImageColors, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_LEVELIZEIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_LEVELIZEIMAGE
 	ZEND_ME(Imagick, levelizeImage, arginfo_class_Imagick_levelizeImage, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_ORDEREDDITHERIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_ORDEREDDITHERIMAGE
 	ZEND_ME(Imagick, orderedDitherImage, arginfo_class_Imagick_orderedDitherImage, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_WHITEBALANCEIMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_WHITEBALANCEIMAGE
 	ZEND_ME(Imagick, whiteBalanceImage, arginfo_class_Imagick_whiteBalanceImage, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_DELETE_OPTION
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_DELETE_OPTION
 	ZEND_ME(Imagick, deleteOption, arginfo_class_Imagick_deleteOption, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_GET_BACKGROUND_COLOR
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_BACKGROUND_COLOR
 	ZEND_ME(Imagick, getBackgroundColor, arginfo_class_Imagick_getBackgroundColor, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_GET_IMAGE_ARTIFACTS
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_ARTIFACTS
 	ZEND_ME(Imagick, getImageArtifacts, arginfo_class_Imagick_getImageArtifacts, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_GET_IMAGE_KURTOSIS
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_KURTOSIS
 	ZEND_ME(Imagick, getImageKurtosis, arginfo_class_Imagick_getImageKurtosis, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_GET_IMAGE_MEAN
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_MEAN
 	ZEND_ME(Imagick, getImageMean, arginfo_class_Imagick_getImageMean, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_GET_IMAGE_RANGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_RANGE
 	ZEND_ME(Imagick, getImageRange, arginfo_class_Imagick_getImageRange, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_GET_INTERPOLATE_METHOD
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_INTERPOLATE_METHOD
 	ZEND_ME(Imagick, getInterpolateMethod, arginfo_class_Imagick_getInterpolateMethod, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_GET_OPTIONS
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_OPTIONS
 	ZEND_ME(Imagick, getOptions, arginfo_class_Imagick_getOptions, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_GET_ORIENTATION
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_ORIENTATION
 	ZEND_ME(Imagick, getOrientation, arginfo_class_Imagick_getOrientation, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_GET_RESOLUTION
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_RESOLUTION
 	ZEND_ME(Imagick, getResolution, arginfo_class_Imagick_getResolution, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_GET_TYPE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_TYPE
 	ZEND_ME(Imagick, getType, arginfo_class_Imagick_getType, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_POLYNOMIAL_IMAGE
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_POLYNOMIAL_IMAGE
 	ZEND_ME(Imagick, polynomialImage, arginfo_class_Imagick_polynomialImage, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_SET_DEPTH
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_DEPTH
 	ZEND_ME(Imagick, setDepth, arginfo_class_Imagick_setDepth, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_SET_EXTRACT
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_EXTRACT
 	ZEND_ME(Imagick, setExtract, arginfo_class_Imagick_setExtract, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_SET_INTERPOLATE_METHOD
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_INTERPOLATE_METHOD
 	ZEND_ME(Imagick, setInterpolateMethod, arginfo_class_Imagick_setInterpolateMethod, ZEND_ACC_PUBLIC)
 #endif
-#if IM_HAVE_IMAGICK_SET_ORIENTATION
+#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_ORIENTATION
 	ZEND_ME(Imagick, setOrientation, arginfo_class_Imagick_setOrientation, ZEND_ACC_PUBLIC)
 #endif
 	ZEND_FE_END

--- a/Imagick_arginfo.h
+++ b/Imagick_arginfo.h
@@ -849,6 +849,24 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_clutImage, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
+#if MagickLibVersion > 0x635 && MagickLibVersion >= 0x700
+
+#if PHP_VERSION_ID >= 80000
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_clutImageWithInterpolate, 0, 2, _IS_BOOL, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_clutImageWithInterpolate, 0, 0, 2)
+#endif
+
+	ZEND_ARG_OBJ_INFO(0, lookup_table, Imagick, 0)
+	
+#if PHP_VERSION_ID >= 80000
+    ZEND_ARG_TYPE_INFO(0, pixel_interpolate_method, IS_LONG, 0)
+#else
+    ZEND_ARG_INFO(0, pixel_interpolate_method)
+#endif
+ZEND_END_ARG_INFO()
+#endif
+
 #if MagickLibVersion > 0x635
 
 #if PHP_VERSION_ID >= 80000
@@ -5079,37 +5097,16 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_Imagick_key arginfo_class_Imagick_getSizeOffset
 #endif
 
-#if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_next, 0, 0, IS_VOID, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_next, 0, 0, 0)
-#endif
-
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_next, 0, 0, IS_VOID, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if MagickLibVersion > 0x628
 #define arginfo_class_Imagick_rewind arginfo_class_Imagick_next
-#endif
 
-#if MagickLibVersion > 0x628
-#define arginfo_class_Imagick_valid arginfo_class_Imagick_optimizeImageLayers
-#endif
+#define arginfo_class_Imagick_valid arginfo_class_Imagick_removeImage
 
-#if MagickLibVersion > 0x628
+#define arginfo_class_Imagick_current arginfo_class_Imagick_clone
 
-#if PHP_VERSION_ID >= 80000
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_current, 0, 0, Imagick, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_current, 0, 0, 0)
-#endif
-
-ZEND_END_ARG_INFO()
-#endif
-
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x659
+#if MagickLibVersion >= 0x659
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_brightnessContrastImage, 0, 2, _IS_BOOL, 0)
@@ -5133,7 +5130,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_brightnessContrastImage, 0, 0, 2)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion > 0x661
+#if MagickLibVersion > 0x661
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_colorMatrixImage, 0, 1, _IS_BOOL, 0)
@@ -5150,7 +5147,6 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_colorMatrixImage, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_selectiveBlurImage, 0, 3, _IS_BOOL, 0)
@@ -5178,9 +5174,8 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_selectiveBlurImage, 0, 0, 3)
 #endif
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
-#endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x689
+#if MagickLibVersion >= 0x689
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_rotationalBlurImage, 0, 1, _IS_BOOL, 0)
@@ -5198,7 +5193,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_rotationalBlurImage, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x683
+#if MagickLibVersion >= 0x683
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_statisticImage, 0, 3, _IS_BOOL, 0)
@@ -5228,7 +5223,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_statisticImage, 0, 0, 3)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x652
+#if MagickLibVersion >= 0x652
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_subimageMatch, 0, 1, Imagick, 0)
@@ -5262,62 +5257,17 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_subimageMatch, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x652
+#if MagickLibVersion >= 0x652
 #define arginfo_class_Imagick_similarityImage arginfo_class_Imagick_subimageMatch
 #endif
 
-#if MagickLibVersion > 0x628
+#define arginfo_class_Imagick_setRegistry arginfo_class_Imagick_setOption
 
-#if PHP_VERSION_ID >= 80000
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setRegistry, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setRegistry, 0, 0, 2)
-#endif
+#define arginfo_class_Imagick_getRegistry arginfo_class_Imagick_getOption
 
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, key)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, value)
-#endif
-ZEND_END_ARG_INFO()
-#endif
+#define arginfo_class_Imagick_listRegistry arginfo_class_Imagick_getImageGeometry
 
-#if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getRegistry, 0, 1, IS_STRING, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getRegistry, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, key)
-#endif
-ZEND_END_ARG_INFO()
-#endif
-
-#if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_listRegistry, 0, 0, IS_ARRAY, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_listRegistry, 0, 0, 0)
-#endif
-
-ZEND_END_ARG_INFO()
-#endif
-
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x680
+#if MagickLibVersion >= 0x680
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_morphology, 0, 3, _IS_BOOL, 0)
@@ -5342,7 +5292,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_morphology, 0, 0, 3)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && defined(IMAGICK_WITH_KERNEL) && MagickLibVersion < 0x700
+#if defined(IMAGICK_WITH_KERNEL) && MagickLibVersion < 0x700
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_filter, 0, 1, _IS_BOOL, 0)
@@ -5355,7 +5305,6 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_filter, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setAntialias, 0, 1, IS_VOID, 0)
@@ -5370,13 +5319,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setAntialias, 0, 0, 1)
     ZEND_ARG_INFO(0, antialias)
 #endif
 ZEND_END_ARG_INFO()
-#endif
 
-#if MagickLibVersion > 0x628
-#define arginfo_class_Imagick_getAntialias arginfo_class_Imagick_optimizeImageLayers
-#endif
+#define arginfo_class_Imagick_getAntialias arginfo_class_Imagick_removeImage
 
-#if MagickLibVersion > 0x628 && MagickLibVersion > 0x676
+#if MagickLibVersion > 0x676
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_colorDecisionListImage, 0, 1, _IS_BOOL, 0)
@@ -5393,7 +5339,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_colorDecisionListImage, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x687
+#if MagickLibVersion >= 0x687
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_optimizeImageTransparency, 0, 0, IS_VOID, 0)
@@ -5404,7 +5350,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_optimizeImageTransparency, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x660
+#if MagickLibVersion >= 0x660
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_autoGammaImage, 0, 0, IS_VOID, 0)
@@ -5416,7 +5362,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_autoGammaImage, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
+#if MagickLibVersion >= 0x692
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_autoOrient, 0, 0, IS_VOID, 0)
@@ -5427,11 +5373,11 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_autoOrient, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
+#if MagickLibVersion >= 0x692
 #define arginfo_class_Imagick_autoOrientate arginfo_class_Imagick_autoOrient
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
+#if MagickLibVersion >= 0x692
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_compositeImageGravity, 0, 3, _IS_BOOL, 0)
@@ -5455,7 +5401,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_compositeImageGravity, 0, 0, 3)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x693
+#if MagickLibVersion >= 0x693
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_localContrastImage, 0, 2, IS_VOID, 0)
@@ -5478,7 +5424,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_localContrastImage, 0, 0, 2)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x700
+#if MagickLibVersion >= 0x700
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_identifyImageType, 0, 0, IS_LONG, 0)
@@ -5489,7 +5435,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_identifyImageType, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GETSETIMAGEMASK
+#if IM_HAVE_IMAGICK_GETSETIMAGEMASK
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getImageMask, 0, 1, Imagick, 1)
@@ -5506,7 +5452,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageMask, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GETSETIMAGEMASK
+#if IM_HAVE_IMAGICK_GETSETIMAGEMASK
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageMask, 0, 2, IS_VOID, 0)
@@ -5524,7 +5470,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageMask, 0, 0, 2)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x709
+#if MagickLibVersion >= 0x709
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_cannyEdgeImage, 0, 4, _IS_BOOL, 0)
@@ -5559,7 +5505,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_cannyEdgeImage, 0, 0, 4)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SETSEED
+#if IM_HAVE_IMAGICK_SETSEED
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setSeed, 0, 1, IS_VOID, 0)
@@ -5576,7 +5522,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setSeed, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_WAVELETDENOISEIMAGE
+#if IM_HAVE_IMAGICK_WAVELETDENOISEIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_waveletDenoiseImage, 0, 2, _IS_BOOL, 0)
@@ -5599,7 +5545,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_waveletDenoiseImage, 0, 0, 2)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_MEANSHIFTIMAGE
+#if IM_HAVE_IMAGICK_MEANSHIFTIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_meanShiftImage, 0, 3, _IS_BOOL, 0)
@@ -5628,7 +5574,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_meanShiftImage, 0, 0, 3)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_KMEANSIMAGE
+#if IM_HAVE_IMAGICK_KMEANSIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_kmeansImage, 0, 3, _IS_BOOL, 0)
@@ -5657,7 +5603,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_kmeansImage, 0, 0, 3)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_RANGETHRESHOLDIMAGE
+#if IM_HAVE_IMAGICK_RANGETHRESHOLDIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_rangeThresholdImage, 0, 4, _IS_BOOL, 0)
@@ -5692,7 +5638,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_rangeThresholdImage, 0, 0, 4)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_AUTOTHRESHOLDIMAGE
+#if IM_HAVE_IMAGICK_AUTOTHRESHOLDIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_autoThresholdImage, 0, 1, _IS_BOOL, 0)
@@ -5709,7 +5655,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_autoThresholdImage, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_BILATERALBLURIMAGE
+#if IM_HAVE_IMAGICK_BILATERALBLURIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_bilateralBlurImage, 0, 4, _IS_BOOL, 0)
@@ -5744,7 +5690,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_bilateralBlurImage, 0, 0, 4)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_CLAHEIMAGE
+#if IM_HAVE_IMAGICK_CLAHEIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_claheImage, 0, 4, _IS_BOOL, 0)
@@ -5779,7 +5725,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_claheImage, 0, 0, 4)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_CHANNELFXIMAGE
+#if IM_HAVE_IMAGICK_CHANNELFXIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_channelFxImage, 0, 1, Imagick, 0)
@@ -5796,7 +5742,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_channelFxImage, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_COLORTHRESHOLDIMAGE
+#if IM_HAVE_IMAGICK_COLORTHRESHOLDIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_colorThresholdImage, 0, 2, _IS_BOOL, 0)
@@ -5809,7 +5755,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_colorThresholdImage, 0, 0, 2)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_COMPLEXIMAGES
+#if IM_HAVE_IMAGICK_COMPLEXIMAGES
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_complexImages, 0, 1, Imagick, 0)
@@ -5826,7 +5772,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_complexImages, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_INTERPOLATIVERESIZEIMAGE
+#if IM_HAVE_IMAGICK_INTERPOLATIVERESIZEIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_interpolativeResizeImage, 0, 3, _IS_BOOL, 0)
@@ -5855,7 +5801,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_interpolativeResizeImage, 0, 0, 3)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_LEVELIMAGECOLORS
+#if IM_HAVE_IMAGICK_LEVELIMAGECOLORS
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_levelImageColors, 0, 3, _IS_BOOL, 0)
@@ -5874,7 +5820,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_levelImageColors, 0, 0, 3)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_LEVELIZEIMAGE
+#if IM_HAVE_IMAGICK_LEVELIZEIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_levelizeImage, 0, 3, _IS_BOOL, 0)
@@ -5903,7 +5849,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_levelizeImage, 0, 0, 3)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_ORDEREDDITHERIMAGE
+#if IM_HAVE_IMAGICK_ORDEREDDITHERIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_orderedDitherImage, 0, 1, _IS_BOOL, 0)
@@ -5920,7 +5866,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_orderedDitherImage, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_WHITEBALANCEIMAGE
+#if IM_HAVE_IMAGICK_WHITEBALANCEIMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_whiteBalanceImage, 0, 0, _IS_BOOL, 0)
@@ -5931,7 +5877,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_whiteBalanceImage, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_DELETE_OPTION
+#if IM_HAVE_IMAGICK_DELETE_OPTION
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_deleteOption, 0, 1, _IS_BOOL, 0)
@@ -5948,7 +5894,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_deleteOption, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_BACKGROUND_COLOR
+#if IM_HAVE_IMAGICK_GET_BACKGROUND_COLOR
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getBackgroundColor, 0, 0, ImagickPixel, 0)
@@ -5959,7 +5905,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getBackgroundColor, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_ARTIFACTS
+#if IM_HAVE_IMAGICK_GET_IMAGE_ARTIFACTS
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageArtifacts, 0, 0, IS_ARRAY, 0)
@@ -5971,7 +5917,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageArtifacts, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_KURTOSIS
+#if IM_HAVE_IMAGICK_GET_IMAGE_KURTOSIS
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageKurtosis, 0, 0, IS_ARRAY, 0)
@@ -5982,7 +5928,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageKurtosis, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_MEAN
+#if IM_HAVE_IMAGICK_GET_IMAGE_MEAN
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageMean, 0, 0, IS_ARRAY, 0)
@@ -5993,7 +5939,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageMean, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_RANGE
+#if IM_HAVE_IMAGICK_GET_IMAGE_RANGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageRange, 0, 0, IS_ARRAY, 0)
@@ -6004,7 +5950,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageRange, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_INTERPOLATE_METHOD
+#if IM_HAVE_IMAGICK_GET_INTERPOLATE_METHOD
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getInterpolateMethod, 0, 0, IS_LONG, 0)
@@ -6015,7 +5961,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getInterpolateMethod, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_OPTIONS
+#if IM_HAVE_IMAGICK_GET_OPTIONS
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getOptions, 0, 0, IS_ARRAY, 0)
@@ -6027,7 +5973,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getOptions, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_ORIENTATION
+#if IM_HAVE_IMAGICK_GET_ORIENTATION
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getOrientation, 0, 0, IS_LONG, 0)
@@ -6038,7 +5984,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getOrientation, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_RESOLUTION
+#if IM_HAVE_IMAGICK_GET_RESOLUTION
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getResolution, 0, 0, IS_ARRAY, 0)
@@ -6049,7 +5995,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getResolution, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_TYPE
+#if IM_HAVE_IMAGICK_GET_TYPE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getType, 0, 0, IS_LONG, 0)
@@ -6060,7 +6006,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getType, 0, 0, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_POLYNOMIAL_IMAGE
+#if IM_HAVE_IMAGICK_POLYNOMIAL_IMAGE
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_polynomialImage, 0, 1, _IS_BOOL, 0)
@@ -6077,7 +6023,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_polynomialImage, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_DEPTH
+#if IM_HAVE_IMAGICK_SET_DEPTH
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setDepth, 0, 1, _IS_BOOL, 0)
@@ -6094,7 +6040,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setDepth, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_EXTRACT
+#if IM_HAVE_IMAGICK_SET_EXTRACT
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setExtract, 0, 1, _IS_BOOL, 0)
@@ -6111,7 +6057,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setExtract, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_INTERPOLATE_METHOD
+#if IM_HAVE_IMAGICK_SET_INTERPOLATE_METHOD
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setInterpolateMethod, 0, 1, _IS_BOOL, 0)
@@ -6128,7 +6074,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setInterpolateMethod, 0, 0, 1)
 ZEND_END_ARG_INFO()
 #endif
 
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_ORIENTATION
+#if IM_HAVE_IMAGICK_SET_ORIENTATION
 
 #if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setOrientation, 0, 1, _IS_BOOL, 0)
@@ -6277,6 +6223,9 @@ ZEND_METHOD(Imagick, paintFloodfillImage);
 #endif
 #if MagickLibVersion > 0x635
 ZEND_METHOD(Imagick, clutImage);
+#endif
+#if MagickLibVersion > 0x635 && MagickLibVersion >= 0x700
+ZEND_METHOD(Imagick, clutImageWithInterpolate);
 #endif
 #if MagickLibVersion > 0x635
 ZEND_METHOD(Imagick, getImageProperties);
@@ -6776,181 +6725,159 @@ ZEND_METHOD(Imagick, setResolution);
 ZEND_METHOD(Imagick, setSamplingFactors);
 ZEND_METHOD(Imagick, setSize);
 ZEND_METHOD(Imagick, setType);
-#if MagickLibVersion > 0x628
-ZEND_METHOD(Imagick, nextImage);
-#endif
-#if MagickLibVersion > 0x628
-ZEND_METHOD(Imagick, setFirstIterator);
-#endif
-#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, valid);
-#endif
-#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, current);
-#endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x659
+#if MagickLibVersion >= 0x659
 ZEND_METHOD(Imagick, brightnessContrastImage);
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion > 0x661
+#if MagickLibVersion > 0x661
 ZEND_METHOD(Imagick, colorMatrixImage);
 #endif
-#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, selectiveBlurImage);
-#endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x689
+#if MagickLibVersion >= 0x689
 ZEND_METHOD(Imagick, rotationalBlurImage);
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x683
+#if MagickLibVersion >= 0x683
 ZEND_METHOD(Imagick, statisticImage);
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x652
+#if MagickLibVersion >= 0x652
 ZEND_METHOD(Imagick, subimageMatch);
 #endif
-#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, setRegistry);
-#endif
-#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, getRegistry);
-#endif
-#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, listRegistry);
-#endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x680
+#if MagickLibVersion >= 0x680
 ZEND_METHOD(Imagick, morphology);
 #endif
-#if MagickLibVersion > 0x628 && defined(IMAGICK_WITH_KERNEL) && MagickLibVersion < 0x700
+#if defined(IMAGICK_WITH_KERNEL) && MagickLibVersion < 0x700
 ZEND_METHOD(Imagick, filter);
 #endif
-#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, setAntialias);
-#endif
-#if MagickLibVersion > 0x628
 ZEND_METHOD(Imagick, getAntialias);
-#endif
-#if MagickLibVersion > 0x628 && MagickLibVersion > 0x676
+#if MagickLibVersion > 0x676
 ZEND_METHOD(Imagick, colorDecisionListImage);
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x687
+#if MagickLibVersion >= 0x687
 ZEND_METHOD(Imagick, optimizeImageTransparency);
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x660
+#if MagickLibVersion >= 0x660
 ZEND_METHOD(Imagick, autoGammaImage);
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
+#if MagickLibVersion >= 0x692
 ZEND_METHOD(Imagick, autoOrient);
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
+#if MagickLibVersion >= 0x692
 ZEND_METHOD(Imagick, compositeImageGravity);
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x693
+#if MagickLibVersion >= 0x693
 ZEND_METHOD(Imagick, localContrastImage);
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x700
+#if MagickLibVersion >= 0x700
 ZEND_METHOD(Imagick, identifyImageType);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GETSETIMAGEMASK
+#if IM_HAVE_IMAGICK_GETSETIMAGEMASK
 ZEND_METHOD(Imagick, getImageMask);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GETSETIMAGEMASK
+#if IM_HAVE_IMAGICK_GETSETIMAGEMASK
 ZEND_METHOD(Imagick, setImageMask);
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x709
+#if MagickLibVersion >= 0x709
 ZEND_METHOD(Imagick, cannyEdgeImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SETSEED
+#if IM_HAVE_IMAGICK_SETSEED
 ZEND_METHOD(Imagick, setSeed);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_WAVELETDENOISEIMAGE
+#if IM_HAVE_IMAGICK_WAVELETDENOISEIMAGE
 ZEND_METHOD(Imagick, waveletDenoiseImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_MEANSHIFTIMAGE
+#if IM_HAVE_IMAGICK_MEANSHIFTIMAGE
 ZEND_METHOD(Imagick, meanShiftImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_KMEANSIMAGE
+#if IM_HAVE_IMAGICK_KMEANSIMAGE
 ZEND_METHOD(Imagick, kmeansImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_RANGETHRESHOLDIMAGE
+#if IM_HAVE_IMAGICK_RANGETHRESHOLDIMAGE
 ZEND_METHOD(Imagick, rangeThresholdImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_AUTOTHRESHOLDIMAGE
+#if IM_HAVE_IMAGICK_AUTOTHRESHOLDIMAGE
 ZEND_METHOD(Imagick, autoThresholdImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_BILATERALBLURIMAGE
+#if IM_HAVE_IMAGICK_BILATERALBLURIMAGE
 ZEND_METHOD(Imagick, bilateralBlurImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_CLAHEIMAGE
+#if IM_HAVE_IMAGICK_CLAHEIMAGE
 ZEND_METHOD(Imagick, claheImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_CHANNELFXIMAGE
+#if IM_HAVE_IMAGICK_CHANNELFXIMAGE
 ZEND_METHOD(Imagick, channelFxImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_COLORTHRESHOLDIMAGE
+#if IM_HAVE_IMAGICK_COLORTHRESHOLDIMAGE
 ZEND_METHOD(Imagick, colorThresholdImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_COMPLEXIMAGES
+#if IM_HAVE_IMAGICK_COMPLEXIMAGES
 ZEND_METHOD(Imagick, complexImages);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_INTERPOLATIVERESIZEIMAGE
+#if IM_HAVE_IMAGICK_INTERPOLATIVERESIZEIMAGE
 ZEND_METHOD(Imagick, interpolativeResizeImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_LEVELIMAGECOLORS
+#if IM_HAVE_IMAGICK_LEVELIMAGECOLORS
 ZEND_METHOD(Imagick, levelImageColors);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_LEVELIZEIMAGE
+#if IM_HAVE_IMAGICK_LEVELIZEIMAGE
 ZEND_METHOD(Imagick, levelizeImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_ORDEREDDITHERIMAGE
+#if IM_HAVE_IMAGICK_ORDEREDDITHERIMAGE
 ZEND_METHOD(Imagick, orderedDitherImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_WHITEBALANCEIMAGE
+#if IM_HAVE_IMAGICK_WHITEBALANCEIMAGE
 ZEND_METHOD(Imagick, whiteBalanceImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_DELETE_OPTION
+#if IM_HAVE_IMAGICK_DELETE_OPTION
 ZEND_METHOD(Imagick, deleteOption);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_BACKGROUND_COLOR
+#if IM_HAVE_IMAGICK_GET_BACKGROUND_COLOR
 ZEND_METHOD(Imagick, getBackgroundColor);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_ARTIFACTS
+#if IM_HAVE_IMAGICK_GET_IMAGE_ARTIFACTS
 ZEND_METHOD(Imagick, getImageArtifacts);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_KURTOSIS
+#if IM_HAVE_IMAGICK_GET_IMAGE_KURTOSIS
 ZEND_METHOD(Imagick, getImageKurtosis);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_MEAN
+#if IM_HAVE_IMAGICK_GET_IMAGE_MEAN
 ZEND_METHOD(Imagick, getImageMean);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_RANGE
+#if IM_HAVE_IMAGICK_GET_IMAGE_RANGE
 ZEND_METHOD(Imagick, getImageRange);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_INTERPOLATE_METHOD
+#if IM_HAVE_IMAGICK_GET_INTERPOLATE_METHOD
 ZEND_METHOD(Imagick, getInterpolateMethod);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_OPTIONS
+#if IM_HAVE_IMAGICK_GET_OPTIONS
 ZEND_METHOD(Imagick, getOptions);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_ORIENTATION
+#if IM_HAVE_IMAGICK_GET_ORIENTATION
 ZEND_METHOD(Imagick, getOrientation);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_RESOLUTION
+#if IM_HAVE_IMAGICK_GET_RESOLUTION
 ZEND_METHOD(Imagick, getResolution);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_TYPE
+#if IM_HAVE_IMAGICK_GET_TYPE
 ZEND_METHOD(Imagick, getType);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_POLYNOMIAL_IMAGE
+#if IM_HAVE_IMAGICK_POLYNOMIAL_IMAGE
 ZEND_METHOD(Imagick, polynomialImage);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_DEPTH
+#if IM_HAVE_IMAGICK_SET_DEPTH
 ZEND_METHOD(Imagick, setDepth);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_EXTRACT
+#if IM_HAVE_IMAGICK_SET_EXTRACT
 ZEND_METHOD(Imagick, setExtract);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_INTERPOLATE_METHOD
+#if IM_HAVE_IMAGICK_SET_INTERPOLATE_METHOD
 ZEND_METHOD(Imagick, setInterpolateMethod);
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_ORIENTATION
+#if IM_HAVE_IMAGICK_SET_ORIENTATION
 ZEND_METHOD(Imagick, setOrientation);
 #endif
 
@@ -7090,6 +7017,9 @@ static const zend_function_entry class_Imagick_methods[] = {
 #endif
 #if MagickLibVersion > 0x635
 	ZEND_ME(Imagick, clutImage, arginfo_class_Imagick_clutImage, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x635 && MagickLibVersion >= 0x700
+	ZEND_ME(Imagick, clutImageWithInterpolate, arginfo_class_Imagick_clutImageWithInterpolate, ZEND_ACC_PUBLIC)
 #endif
 #if MagickLibVersion > 0x635
 	ZEND_ME(Imagick, getImageProperties, arginfo_class_Imagick_getImageProperties, ZEND_ACC_PUBLIC)
@@ -7594,187 +7524,167 @@ static const zend_function_entry class_Imagick_methods[] = {
 #if MagickLibVersion > 0x628
 	ZEND_MALIAS(Imagick, key, getIteratorIndex, arginfo_class_Imagick_key, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628
 	ZEND_MALIAS(Imagick, next, nextImage, arginfo_class_Imagick_next, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_MALIAS(Imagick, rewind, setFirstIterator, arginfo_class_Imagick_rewind, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, valid, arginfo_class_Imagick_valid, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, current, arginfo_class_Imagick_current, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x659
+#if MagickLibVersion >= 0x659
 	ZEND_ME(Imagick, brightnessContrastImage, arginfo_class_Imagick_brightnessContrastImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion > 0x661
+#if MagickLibVersion > 0x661
 	ZEND_ME(Imagick, colorMatrixImage, arginfo_class_Imagick_colorMatrixImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, selectiveBlurImage, arginfo_class_Imagick_selectiveBlurImage, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x689
+#if MagickLibVersion >= 0x689
 	ZEND_ME(Imagick, rotationalBlurImage, arginfo_class_Imagick_rotationalBlurImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x683
+#if MagickLibVersion >= 0x683
 	ZEND_ME(Imagick, statisticImage, arginfo_class_Imagick_statisticImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x652
+#if MagickLibVersion >= 0x652
 	ZEND_ME(Imagick, subimageMatch, arginfo_class_Imagick_subimageMatch, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x652
+#if MagickLibVersion >= 0x652
 	ZEND_MALIAS(Imagick, similarityImage, subimageMatch, arginfo_class_Imagick_similarityImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, setRegistry, arginfo_class_Imagick_setRegistry, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, getRegistry, arginfo_class_Imagick_getRegistry, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, listRegistry, arginfo_class_Imagick_listRegistry, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-#endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x680
+#if MagickLibVersion >= 0x680
 	ZEND_ME(Imagick, morphology, arginfo_class_Imagick_morphology, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && defined(IMAGICK_WITH_KERNEL) && MagickLibVersion < 0x700
+#if defined(IMAGICK_WITH_KERNEL) && MagickLibVersion < 0x700
 	ZEND_ME(Imagick, filter, arginfo_class_Imagick_filter, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
 #endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, setAntialias, arginfo_class_Imagick_setAntialias, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, getAntialias, arginfo_class_Imagick_getAntialias, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628 && MagickLibVersion > 0x676
+#if MagickLibVersion > 0x676
 	ZEND_ME(Imagick, colorDecisionListImage, arginfo_class_Imagick_colorDecisionListImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x687
+#if MagickLibVersion >= 0x687
 	ZEND_ME(Imagick, optimizeImageTransparency, arginfo_class_Imagick_optimizeImageTransparency, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x660
+#if MagickLibVersion >= 0x660
 	ZEND_ME(Imagick, autoGammaImage, arginfo_class_Imagick_autoGammaImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
+#if MagickLibVersion >= 0x692
 	ZEND_ME(Imagick, autoOrient, arginfo_class_Imagick_autoOrient, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
+#if MagickLibVersion >= 0x692
 	ZEND_MALIAS(Imagick, autoOrientate, autoOrient, arginfo_class_Imagick_autoOrientate, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
+#if MagickLibVersion >= 0x692
 	ZEND_ME(Imagick, compositeImageGravity, arginfo_class_Imagick_compositeImageGravity, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x693
+#if MagickLibVersion >= 0x693
 	ZEND_ME(Imagick, localContrastImage, arginfo_class_Imagick_localContrastImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x700
+#if MagickLibVersion >= 0x700
 	ZEND_ME(Imagick, identifyImageType, arginfo_class_Imagick_identifyImageType, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GETSETIMAGEMASK
+#if IM_HAVE_IMAGICK_GETSETIMAGEMASK
 	ZEND_ME(Imagick, getImageMask, arginfo_class_Imagick_getImageMask, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GETSETIMAGEMASK
+#if IM_HAVE_IMAGICK_GETSETIMAGEMASK
 	ZEND_ME(Imagick, setImageMask, arginfo_class_Imagick_setImageMask, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && MagickLibVersion >= 0x709
+#if MagickLibVersion >= 0x709
 	ZEND_ME(Imagick, cannyEdgeImage, arginfo_class_Imagick_cannyEdgeImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SETSEED
+#if IM_HAVE_IMAGICK_SETSEED
 	ZEND_ME(Imagick, setSeed, arginfo_class_Imagick_setSeed, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_WAVELETDENOISEIMAGE
+#if IM_HAVE_IMAGICK_WAVELETDENOISEIMAGE
 	ZEND_ME(Imagick, waveletDenoiseImage, arginfo_class_Imagick_waveletDenoiseImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_MEANSHIFTIMAGE
+#if IM_HAVE_IMAGICK_MEANSHIFTIMAGE
 	ZEND_ME(Imagick, meanShiftImage, arginfo_class_Imagick_meanShiftImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_KMEANSIMAGE
+#if IM_HAVE_IMAGICK_KMEANSIMAGE
 	ZEND_ME(Imagick, kmeansImage, arginfo_class_Imagick_kmeansImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_RANGETHRESHOLDIMAGE
+#if IM_HAVE_IMAGICK_RANGETHRESHOLDIMAGE
 	ZEND_ME(Imagick, rangeThresholdImage, arginfo_class_Imagick_rangeThresholdImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_AUTOTHRESHOLDIMAGE
+#if IM_HAVE_IMAGICK_AUTOTHRESHOLDIMAGE
 	ZEND_ME(Imagick, autoThresholdImage, arginfo_class_Imagick_autoThresholdImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_BILATERALBLURIMAGE
+#if IM_HAVE_IMAGICK_BILATERALBLURIMAGE
 	ZEND_ME(Imagick, bilateralBlurImage, arginfo_class_Imagick_bilateralBlurImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_CLAHEIMAGE
+#if IM_HAVE_IMAGICK_CLAHEIMAGE
 	ZEND_ME(Imagick, claheImage, arginfo_class_Imagick_claheImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_CHANNELFXIMAGE
+#if IM_HAVE_IMAGICK_CHANNELFXIMAGE
 	ZEND_ME(Imagick, channelFxImage, arginfo_class_Imagick_channelFxImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_COLORTHRESHOLDIMAGE
+#if IM_HAVE_IMAGICK_COLORTHRESHOLDIMAGE
 	ZEND_ME(Imagick, colorThresholdImage, arginfo_class_Imagick_colorThresholdImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_COMPLEXIMAGES
+#if IM_HAVE_IMAGICK_COMPLEXIMAGES
 	ZEND_ME(Imagick, complexImages, arginfo_class_Imagick_complexImages, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_INTERPOLATIVERESIZEIMAGE
+#if IM_HAVE_IMAGICK_INTERPOLATIVERESIZEIMAGE
 	ZEND_ME(Imagick, interpolativeResizeImage, arginfo_class_Imagick_interpolativeResizeImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_LEVELIMAGECOLORS
+#if IM_HAVE_IMAGICK_LEVELIMAGECOLORS
 	ZEND_ME(Imagick, levelImageColors, arginfo_class_Imagick_levelImageColors, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_LEVELIZEIMAGE
+#if IM_HAVE_IMAGICK_LEVELIZEIMAGE
 	ZEND_ME(Imagick, levelizeImage, arginfo_class_Imagick_levelizeImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_ORDEREDDITHERIMAGE
+#if IM_HAVE_IMAGICK_ORDEREDDITHERIMAGE
 	ZEND_ME(Imagick, orderedDitherImage, arginfo_class_Imagick_orderedDitherImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_WHITEBALANCEIMAGE
+#if IM_HAVE_IMAGICK_WHITEBALANCEIMAGE
 	ZEND_ME(Imagick, whiteBalanceImage, arginfo_class_Imagick_whiteBalanceImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_DELETE_OPTION
+#if IM_HAVE_IMAGICK_DELETE_OPTION
 	ZEND_ME(Imagick, deleteOption, arginfo_class_Imagick_deleteOption, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_BACKGROUND_COLOR
+#if IM_HAVE_IMAGICK_GET_BACKGROUND_COLOR
 	ZEND_ME(Imagick, getBackgroundColor, arginfo_class_Imagick_getBackgroundColor, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_ARTIFACTS
+#if IM_HAVE_IMAGICK_GET_IMAGE_ARTIFACTS
 	ZEND_ME(Imagick, getImageArtifacts, arginfo_class_Imagick_getImageArtifacts, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_KURTOSIS
+#if IM_HAVE_IMAGICK_GET_IMAGE_KURTOSIS
 	ZEND_ME(Imagick, getImageKurtosis, arginfo_class_Imagick_getImageKurtosis, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_MEAN
+#if IM_HAVE_IMAGICK_GET_IMAGE_MEAN
 	ZEND_ME(Imagick, getImageMean, arginfo_class_Imagick_getImageMean, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_RANGE
+#if IM_HAVE_IMAGICK_GET_IMAGE_RANGE
 	ZEND_ME(Imagick, getImageRange, arginfo_class_Imagick_getImageRange, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_INTERPOLATE_METHOD
+#if IM_HAVE_IMAGICK_GET_INTERPOLATE_METHOD
 	ZEND_ME(Imagick, getInterpolateMethod, arginfo_class_Imagick_getInterpolateMethod, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_OPTIONS
+#if IM_HAVE_IMAGICK_GET_OPTIONS
 	ZEND_ME(Imagick, getOptions, arginfo_class_Imagick_getOptions, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_ORIENTATION
+#if IM_HAVE_IMAGICK_GET_ORIENTATION
 	ZEND_ME(Imagick, getOrientation, arginfo_class_Imagick_getOrientation, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_RESOLUTION
+#if IM_HAVE_IMAGICK_GET_RESOLUTION
 	ZEND_ME(Imagick, getResolution, arginfo_class_Imagick_getResolution, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_TYPE
+#if IM_HAVE_IMAGICK_GET_TYPE
 	ZEND_ME(Imagick, getType, arginfo_class_Imagick_getType, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_POLYNOMIAL_IMAGE
+#if IM_HAVE_IMAGICK_POLYNOMIAL_IMAGE
 	ZEND_ME(Imagick, polynomialImage, arginfo_class_Imagick_polynomialImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_DEPTH
+#if IM_HAVE_IMAGICK_SET_DEPTH
 	ZEND_ME(Imagick, setDepth, arginfo_class_Imagick_setDepth, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_EXTRACT
+#if IM_HAVE_IMAGICK_SET_EXTRACT
 	ZEND_ME(Imagick, setExtract, arginfo_class_Imagick_setExtract, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_INTERPOLATE_METHOD
+#if IM_HAVE_IMAGICK_SET_INTERPOLATE_METHOD
 	ZEND_ME(Imagick, setInterpolateMethod, arginfo_class_Imagick_setInterpolateMethod, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_ORIENTATION
+#if IM_HAVE_IMAGICK_SET_ORIENTATION
 	ZEND_ME(Imagick, setOrientation, arginfo_class_Imagick_setOrientation, ZEND_ACC_PUBLIC)
 #endif
 	ZEND_FE_END

--- a/Imagick_arginfo.h
+++ b/Imagick_arginfo.h
@@ -1,73 +1,27 @@
 /* This is a generated file, edit the .stub.php file instead.
-* Stub hash: regen with 'sh regen_arginfo.sh' 
-* file has been fixedup for different versions */
+ * Stub hash: a1985d42e32acb2cd88c02e8b7dafee699863f4b */
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_optimizeImageLayers, 0, 0, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_optimizeImageLayers, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_compareImageLayers, 0, 1, Imagick, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_compareImageLayers, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, metric)
-#endif
+	ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_pingImageBlob, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_pingImageBlob, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, image, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, image)
-#endif
+	ZEND_ARG_TYPE_INFO(0, image, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_pingImageFile, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_pingImageFile, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, filehandle, IS_MIXED, 0)
-#else
-    ZEND_ARG_INFO(0, filehandle)
-#endif
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filename, IS_STRING, 1, "null")
-#else
-    ZEND_ARG_INFO(0, filename)
-#endif
-
+	ZEND_ARG_TYPE_INFO(0, filehandle, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filename, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 #endif
 
@@ -80,106 +34,32 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_trimImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_trimImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, fuzz)
-#endif
+	ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_waveImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_waveImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, amplitude, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, amplitude)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, length, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, length)
-#endif
+	ZEND_ARG_TYPE_INFO(0, amplitude, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, length, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && MagickLibVersion >= 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_waveImageWithMethod, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_waveImageWithMethod, 0, 0, 3)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, amplitude, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, amplitude)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, length, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, length)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, interpolate_method, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, interpolate_method)
-#endif
+	ZEND_ARG_TYPE_INFO(0, amplitude, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, length, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, interpolate_method, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_vignetteImage, 0, 4, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_vignetteImage, 0, 0, 4)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, black_point, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, black_point)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, white_point, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, white_point)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, x)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, y)
-#endif
+	ZEND_ARG_TYPE_INFO(0, black_point, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, white_point, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
@@ -188,212 +68,66 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageMatte, 0, 0, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageMatte, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageMatte, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageMatte, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, matte, _IS_BOOL, 0)
-#else
-    ZEND_ARG_INFO(0, matte)
-#endif
+	ZEND_ARG_TYPE_INFO(0, matte, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_adaptiveResizeImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_adaptiveResizeImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, columns)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, rows)
-#endif
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bestfit, _IS_BOOL, 0, "false")
-#else
-    ZEND_ARG_INFO(0, bestfit)
-#endif
-
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
-#else
-    ZEND_ARG_INFO(0, legacy)
-#endif
-
+	ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bestfit, _IS_BOOL, 0, "false")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_sketchImage, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_sketchImage, 0, 0, 3)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, radius)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, sigma)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, angle)
-#endif
+	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_shadeImage, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_shadeImage, 0, 0, 3)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, gray, _IS_BOOL, 0)
-#else
-    ZEND_ARG_INFO(0, gray)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, azimuth, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, azimuth)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, elevation, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, elevation)
-#endif
+	ZEND_ARG_TYPE_INFO(0, gray, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, azimuth, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, elevation, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getSizeOffset, 0, 0, IS_LONG, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getSizeOffset, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setSizeOffset, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setSizeOffset, 0, 0, 3)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, columns)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, rows)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, offset)
-#endif
+	ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_adaptiveBlurImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_adaptiveBlurImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, radius)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, sigma)
-#endif
+	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_contrastStretchImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_contrastStretchImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, black_point, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, black_point)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, white_point, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, white_point)
-#endif
+	ZEND_ARG_TYPE_INFO(0, black_point, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, white_point, IS_DOUBLE, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
@@ -403,63 +137,19 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_randomThresholdImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_randomThresholdImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, low, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, low)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, high, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, high)
-#endif
+	ZEND_ARG_TYPE_INFO(0, low, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, high, IS_DOUBLE, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_roundCornersImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_roundCornersImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x_rounding, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, x_rounding)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, y_rounding, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, y_rounding)
-#endif
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, stroke_width, IS_DOUBLE, 0, "10")
-#else
-    ZEND_ARG_INFO(0, stroke_width)
-#endif
-
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, displace, IS_DOUBLE, 0, "5")
-#else
-    ZEND_ARG_INFO(0, displace)
-#endif
-
+	ZEND_ARG_TYPE_INFO(0, x_rounding, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, y_rounding, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, stroke_width, IS_DOUBLE, 0, "10")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, displace, IS_DOUBLE, 0, "5")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, size_correction, IS_DOUBLE, 0, "-6")
 ZEND_END_ARG_INFO()
 #endif
@@ -469,19 +159,8 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setIteratorIndex, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setIteratorIndex, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, index)
-#endif
+	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
@@ -490,250 +169,87 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && MagickLibVersion < 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_transformImage, 0, 2, Imagick, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_transformImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, crop, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, crop)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, geometry, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, geometry)
-#endif
+	ZEND_ARG_TYPE_INFO(0, crop, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, geometry, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x630 && MagickLibVersion < 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageOpacity, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageOpacity, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, opacity, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, opacity)
-#endif
+	ZEND_ARG_TYPE_INFO(0, opacity, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x630 && MagickLibVersion >= 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageAlpha, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageAlpha, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, alpha, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, alpha)
-#endif
+	ZEND_ARG_TYPE_INFO(0, alpha, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x630 && MagickLibVersion < 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_orderedPosterizeImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_orderedPosterizeImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, threshold_map, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, threshold_map)
-#endif
+	ZEND_ARG_TYPE_INFO(0, threshold_map, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion >= 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_polaroidWithTextAndMethod, 0, 4, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_polaroidWithTextAndMethod, 0, 0, 4)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, settings, ImagickDraw, 0)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, angle)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, caption, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, caption)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, method, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, method)
-#endif
+	ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, caption, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, method, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x631
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_polaroidImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_polaroidImage, 0, 0, 2)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, settings, ImagickDraw, 0)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, angle)
-#endif
+	ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x631
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageProperty, 0, 1, IS_STRING, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageProperty, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, name)
-#endif
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x631
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageProperty, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageProperty, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, name)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, value)
-#endif
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x631
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_deleteImageProperty, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_deleteImageProperty, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, name)
-#endif
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x631
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_identifyFormat, 0, 1, IS_STRING, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_identifyFormat, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, format, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, format)
-#endif
+	ZEND_ARG_TYPE_INFO(0, format, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x631 && IM_HAVE_IMAGICK_SETIMAGEINTERPOLATEMETHOD
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageInterpolateMethod, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageInterpolateMethod, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, method, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, method)
-#endif
+	ZEND_ARG_TYPE_INFO(0, method, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x631
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageInterpolateMethod, 0, 0, IS_LONG, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageInterpolateMethod, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x631
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_linearStretchImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_linearStretchImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, black_point, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, black_point)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, white_point, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, white_point)
-#endif
+	ZEND_ARG_TYPE_INFO(0, black_point, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, white_point, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
@@ -742,129 +258,54 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x631
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_extentImage, 0, 4, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_extentImage, 0, 0, 4)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, width)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, height)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, x)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, y)
-#endif
+	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x633
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageOrientation, 0, 0, IS_LONG, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageOrientation, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x633
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageOrientation, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageOrientation, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, orientation, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, orientation)
-#endif
+	ZEND_ARG_TYPE_INFO(0, orientation, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion > 0x634 && MagickLibVersion < 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_paintFloodfillImage, 0, 5, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_paintFloodfillImage, 0, 0, 5)
-#endif
-
 	ZEND_ARG_OBJ_TYPE_MASK(0, fill_color, ImagickPixel, MAY_BE_STRING, NULL)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, fuzz)
-#endif
+	ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, border_color, ImagickPixel, MAY_BE_STRING, NULL)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, x)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, y)
-#endif
+	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x635
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_clutImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_clutImage, 0, 0, 1)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, lookup_table, Imagick, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
+#if MagickLibVersion > 0x635 && MagickLibVersion > 0x700
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_clutImageWithInterpolate, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_OBJ_INFO(0, lookup_table, Imagick, 0)
+	ZEND_ARG_TYPE_INFO(0, pixel_interpolate_method, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+#endif
+
 #if MagickLibVersion > 0x635
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageProperties, 0, 0, IS_ARRAY, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageProperties, 0, 0, 0)
-#endif
-
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, pattern, IS_STRING, 0, "\"*\"")
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, include_values, _IS_BOOL, 0, "true")
-#else
-    ZEND_ARG_INFO(0, include_values)
-#endif
-
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, include_values, _IS_BOOL, 0, "true")
 ZEND_END_ARG_INFO()
 #endif
 
@@ -873,55 +314,17 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x635
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_distortImage, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_distortImage, 0, 0, 3)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, distortion, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, distortion)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, arguments, IS_ARRAY, 0)
-#else
-    ZEND_ARG_INFO(0, arguments)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, bestfit, _IS_BOOL, 0)
-#else
-    ZEND_ARG_INFO(0, bestfit)
-#endif
+	ZEND_ARG_TYPE_INFO(0, distortion, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, arguments, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, bestfit, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x635
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_writeImageFile, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_writeImageFile, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, filehandle, IS_MIXED, 0)
-#else
-    ZEND_ARG_INFO(0, filehandle)
-#endif
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, format, IS_STRING, 1, "null")
-#else
-    ZEND_ARG_INFO(0, format)
-#endif
-
+	ZEND_ARG_TYPE_INFO(0, filehandle, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, format, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 #endif
 
@@ -930,312 +333,111 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x635
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_resetImagePage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_resetImagePage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, page, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, page)
-#endif
+	ZEND_ARG_TYPE_INFO(0, page, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x635 && MagickLibVersion < 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageClipMask, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageClipMask, 0, 0, 1)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, clip_mask, imagick, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x635 && MagickLibVersion < 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getImageClipMask, 0, 0, Imagick, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageClipMask, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x635
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_animateImages, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_animateImages, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x_server, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, x_server)
-#endif
+	ZEND_ARG_TYPE_INFO(0, x_server, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x635 && !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_recolorImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_recolorImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, matrix, IS_ARRAY, 0)
-#else
-    ZEND_ARG_INFO(0, matrix)
-#endif
+	ZEND_ARG_TYPE_INFO(0, matrix, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x636
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setFont, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setFont, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, font, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, font)
-#endif
+	ZEND_ARG_TYPE_INFO(0, font, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x636
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getFont, 0, 0, IS_STRING, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getFont, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x636
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setPointSize, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setPointSize, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, point_size, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, point_size)
-#endif
+	ZEND_ARG_TYPE_INFO(0, point_size, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x636
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getPointSize, 0, 0, IS_DOUBLE, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getPointSize, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x636
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_mergeImageLayers, 0, 1, Imagick, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_mergeImageLayers, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, layermethod, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, layermethod)
-#endif
+	ZEND_ARG_TYPE_INFO(0, layermethod, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x637
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageAlphaChannel, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageAlphaChannel, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, alphachannel, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, alphachannel)
-#endif
+	ZEND_ARG_TYPE_INFO(0, alphachannel, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x637
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_floodfillPaintImage, 0, 6, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_floodfillPaintImage, 0, 0, 6)
-#endif
-
 	ZEND_ARG_OBJ_TYPE_MASK(0, fill_color, ImagickPixel, MAY_BE_STRING, NULL)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, fuzz)
-#endif
+	ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, border_color, ImagickPixel, MAY_BE_STRING, NULL)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, x)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, y)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, invert, _IS_BOOL, 0)
-#else
-    ZEND_ARG_INFO(0, invert)
-#endif
+	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, invert, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 1, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x637
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_opaquePaintImage, 0, 4, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_opaquePaintImage, 0, 0, 4)
-#endif
-
 	ZEND_ARG_OBJ_TYPE_MASK(0, target_color, ImagickPixel, MAY_BE_STRING, NULL)
 	ZEND_ARG_OBJ_TYPE_MASK(0, fill_color, ImagickPixel, MAY_BE_STRING, NULL)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, fuzz)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, invert, _IS_BOOL, 0)
-#else
-    ZEND_ARG_INFO(0, invert)
-#endif
+	ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, invert, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x637
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_transparentPaintImage, 0, 4, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_transparentPaintImage, 0, 0, 4)
-#endif
-
 	ZEND_ARG_OBJ_TYPE_MASK(0, target_color, ImagickPixel, MAY_BE_STRING, NULL)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, alpha, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, alpha)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, fuzz)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, invert, _IS_BOOL, 0)
-#else
-    ZEND_ARG_INFO(0, invert)
-#endif
+	ZEND_ARG_TYPE_INFO(0, alpha, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, invert, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x638
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_liquidRescaleImage, 0, 4, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_liquidRescaleImage, 0, 0, 4)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, width)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, height)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, delta_x, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, delta_x)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, rigidity, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, rigidity)
-#endif
+	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, delta_x, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, rigidity, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x638
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_encipherImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_encipherImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, passphrase, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, passphrase)
-#endif
+	ZEND_ARG_TYPE_INFO(0, passphrase, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
@@ -1244,861 +446,268 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x639
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setGravity, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setGravity, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, gravity, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, gravity)
-#endif
+	ZEND_ARG_TYPE_INFO(0, gravity, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x639
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getGravity, 0, 0, IS_LONG, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getGravity, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x639
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageChannelRange, 0, 1, IS_ARRAY, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageChannelRange, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, channel)
-#endif
+	ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x639
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageAlphaChannel, 0, 0, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageAlphaChannel, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x642
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageChannelDistortions, 0, 2, IS_DOUBLE, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageChannelDistortions, 0, 0, 2)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, reference_image, Imagick, 0)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, metric)
-#endif
+	ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x643
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageGravity, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageGravity, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, gravity, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, gravity)
-#endif
+	ZEND_ARG_TYPE_INFO(0, gravity, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x643
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageGravity, 0, 0, IS_LONG, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageGravity, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x645
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_importImagePixels, 0, 7, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_importImagePixels, 0, 0, 7)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, x)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, y)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, width)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, height)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, map, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, map)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, pixelstorage, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, pixelstorage)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, pixels, IS_ARRAY, 0)
-#else
-    ZEND_ARG_INFO(0, pixels)
-#endif
+	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, map, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, pixelstorage, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, pixels, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x645
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_deskewImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_deskewImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, threshold)
-#endif
+	ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x645
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_segmentImage, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_segmentImage, 0, 0, 3)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, colorspace)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, cluster_threshold, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, cluster_threshold)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, smooth_threshold, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, smooth_threshold)
-#endif
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, verbose, _IS_BOOL, 0, "false")
-#else
-    ZEND_ARG_INFO(0, verbose)
-#endif
-
+	ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, cluster_threshold, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, smooth_threshold, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, verbose, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x645
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_sparseColorImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_sparseColorImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, sparsecolormethod, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, sparsecolormethod)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, arguments, IS_ARRAY, 0)
-#else
-    ZEND_ARG_INFO(0, arguments)
-#endif
+	ZEND_ARG_TYPE_INFO(0, sparsecolormethod, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, arguments, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x645
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_remapImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_remapImage, 0, 0, 2)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, replacement, Imagick, 0)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, dither_method, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, dither_method)
-#endif
+	ZEND_ARG_TYPE_INFO(0, dither_method, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if PHP_IMAGICK_HAVE_HOUGHLINE
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_houghLineImage, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_houghLineImage, 0, 0, 3)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, width)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, height)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, threshold)
-#endif
+	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x646
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_exportImagePixels, 0, 6, IS_ARRAY, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_exportImagePixels, 0, 0, 6)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, x)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, y)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, width)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, height)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, map, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, map)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, pixelstorage, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, pixelstorage)
-#endif
+	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, map, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, pixelstorage, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x648
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageChannelKurtosis, 0, 0, IS_ARRAY, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageChannelKurtosis, 0, 0, 0)
-#endif
-
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x648
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_functionImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_functionImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, function, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, function)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, parameters, IS_ARRAY, 0)
-#else
-    ZEND_ARG_INFO(0, parameters)
-#endif
+	ZEND_ARG_TYPE_INFO(0, function, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, parameters, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x651
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_transformImageColorspace, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_transformImageColorspace, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, colorspace)
-#endif
+	ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x652
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_haldClutImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_haldClutImage, 0, 0, 1)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, clut, Imagick, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x655
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_autoLevelImage, 0, 0, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_autoLevelImage, 0, 0, 0)
-#endif
-
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x655
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_blueShiftImage, 0, 0, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_blueShiftImage, 0, 0, 0)
-#endif
-
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, factor, IS_DOUBLE, 0, "1.5")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x656
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageArtifact, 0, 1, IS_STRING, 1)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageArtifact, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, artifact, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, artifact)
-#endif
+	ZEND_ARG_TYPE_INFO(0, artifact, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x656
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageArtifact, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageArtifact, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, artifact, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, artifact)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 1)
-#else
-    ZEND_ARG_INFO(0, value)
-#endif
+	ZEND_ARG_TYPE_INFO(0, artifact, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 1)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x656
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_deleteImageArtifact, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_deleteImageArtifact, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, artifact, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, artifact)
-#endif
+	ZEND_ARG_TYPE_INFO(0, artifact, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x656
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getColorspace, 0, 0, IS_LONG, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getColorspace, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x656
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setColorspace, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setColorspace, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, colorspace)
-#endif
+	ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x656
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_clampImage, 0, 0, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_clampImage, 0, 0, 0)
-#endif
-
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x667
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_smushImages, 0, 2, Imagick, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_smushImages, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, stack, _IS_BOOL, 0)
-#else
-    ZEND_ARG_INFO(0, stack)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, offset)
-#endif
+	ZEND_ARG_TYPE_INFO(0, stack, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick___construct, 0, 0, 0)
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_MASK(0, files, MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_LONG|MAY_BE_DOUBLE|MAY_BE_NULL, "null")
-#else
-    ZEND_ARG_INFO(0, files)
-#endif
-
+	ZEND_ARG_TYPE_MASK(0, files, MAY_BE_STRING|MAY_BE_ARRAY|MAY_BE_LONG|MAY_BE_DOUBLE|MAY_BE_NULL, "null")
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick___toString, 0, 0, IS_STRING, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick___toString, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 
 #if PHP_VERSION_ID >= 50600
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_count, 0, 0, IS_LONG, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_count, 0, 0, 0)
-#endif
-
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "0")
-#else
-    ZEND_ARG_INFO(0, mode)
-#endif
-
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 #endif
 
 #if !(PHP_VERSION_ID >= 50600)
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_count, 0, 0, IS_LONG, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_count, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getPixelIterator, 0, 0, ImagickPixelIterator, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getPixelIterator, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getPixelRegionIterator, 0, 4, ImagickPixelIterator, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getPixelRegionIterator, 0, 0, 4)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, x)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, y)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, columns)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, rows)
-#endif
+	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_readImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_readImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, filename)
-#endif
+	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_readImages, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_readImages, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, filenames, IS_ARRAY, 0)
-#else
-    ZEND_ARG_INFO(0, filenames)
-#endif
+	ZEND_ARG_TYPE_INFO(0, filenames, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_readImageBlob, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_readImageBlob, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, image, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, image)
-#endif
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filename, IS_STRING, 1, "null")
-#else
-    ZEND_ARG_INFO(0, filename)
-#endif
-
+	ZEND_ARG_TYPE_INFO(0, image, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filename, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageFormat, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageFormat, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, format, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, format)
-#endif
+	ZEND_ARG_TYPE_INFO(0, format, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_scaleImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_scaleImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, columns)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, rows)
-#endif
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bestfit, _IS_BOOL, 0, "false")
-#else
-    ZEND_ARG_INFO(0, bestfit)
-#endif
-
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
-#else
-    ZEND_ARG_INFO(0, legacy)
-#endif
-
+	ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bestfit, _IS_BOOL, 0, "false")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_writeImage, 0, 0, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_writeImage, 0, 0, 0)
-#endif
-
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filename, IS_STRING, 1, "null")
-#else
-    ZEND_ARG_INFO(0, filename)
-#endif
-
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filename, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_writeImages, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_writeImages, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, filename)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, adjoin, _IS_BOOL, 0)
-#else
-    ZEND_ARG_INFO(0, adjoin)
-#endif
+	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, adjoin, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_blurImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_blurImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, radius)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, sigma)
-#endif
+	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_thumbnailImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_thumbnailImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 1)
-#else
-    ZEND_ARG_INFO(0, columns)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 1)
-#else
-    ZEND_ARG_INFO(0, rows)
-#endif
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bestfit, _IS_BOOL, 0, "false")
-#else
-    ZEND_ARG_INFO(0, bestfit)
-#endif
-
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, fill, _IS_BOOL, 0, "false")
-#else
-    ZEND_ARG_INFO(0, fill)
-#endif
-
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
-#else
-    ZEND_ARG_INFO(0, legacy)
-#endif
-
+	ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 1)
+	ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 1)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bestfit, _IS_BOOL, 0, "false")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, fill, _IS_BOOL, 0, "false")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_cropThumbnailImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_cropThumbnailImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, width)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, height)
-#endif
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
-#else
-    ZEND_ARG_INFO(0, legacy)
-#endif
-
+	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageFilename arginfo_class_Imagick___toString
@@ -2109,35 +718,17 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageMimeType arginfo_class_Imagick___toString
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_removeImage, 0, 0, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_removeImage, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_destroy arginfo_class_Imagick_removeImage
 
 #define arginfo_class_Imagick_clear arginfo_class_Imagick_removeImage
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_clone, 0, 0, Imagick, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_clone, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageSize, 0, 0, IS_LONG, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageSize, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageBlob arginfo_class_Imagick___toString
@@ -2148,13 +739,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_setLastIterator arginfo_class_Imagick_removeImage
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_resetIterator, 0, 0, IS_VOID, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_resetIterator, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_previousImage arginfo_class_Imagick_removeImage
@@ -2165,817 +750,224 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_hasNextImage arginfo_class_Imagick_removeImage
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageIndex, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageIndex, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, index)
-#endif
+	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageIndex arginfo_class_Imagick_getImageSize
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_commentImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_commentImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, comment, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, comment)
-#endif
+	ZEND_ARG_TYPE_INFO(0, comment, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_cropImage, 0, 4, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_cropImage, 0, 0, 4)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, width)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, height)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, x)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, y)
-#endif
+	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_labelImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_labelImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, label, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, label)
-#endif
+	ZEND_ARG_TYPE_INFO(0, label, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageGeometry, 0, 0, IS_ARRAY, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageGeometry, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_drawImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_drawImage, 0, 0, 1)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, drawing, ImagickDraw, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageCompressionQuality, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageCompressionQuality, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, quality, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, quality)
-#endif
+	ZEND_ARG_TYPE_INFO(0, quality, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageCompressionQuality arginfo_class_Imagick_getImageSize
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageCompression, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageCompression, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, compression, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, compression)
-#endif
+	ZEND_ARG_TYPE_INFO(0, compression, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageCompression arginfo_class_Imagick_getImageSize
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_annotateImage, 0, 5, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_annotateImage, 0, 0, 5)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, settings, ImagickDraw, 0)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, x)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, y, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, y)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, angle)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, text, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, text)
-#endif
+	ZEND_ARG_TYPE_INFO(0, x, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, y, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, text, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_compositeImage, 0, 4, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_compositeImage, 0, 0, 4)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, composite_image, Imagick, 0)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, composite, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, composite)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, x)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, y)
-#endif
+	ZEND_ARG_TYPE_INFO(0, composite, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_modulateImage, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_modulateImage, 0, 0, 3)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, brightness, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, brightness)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, saturation, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, saturation)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, hue, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, hue)
-#endif
+	ZEND_ARG_TYPE_INFO(0, brightness, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, saturation, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, hue, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageColors arginfo_class_Imagick_getImageSize
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_montageImage, 0, 5, Imagick, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_montageImage, 0, 0, 5)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, settings, ImagickDraw, 0)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, tile_geometry, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, tile_geometry)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, thumbnail_geometry, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, thumbnail_geometry)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, monatgemode, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, monatgemode)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, frame, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, frame)
-#endif
+	ZEND_ARG_TYPE_INFO(0, tile_geometry, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, thumbnail_geometry, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, monatgemode, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, frame, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_identifyImage, 0, 0, IS_ARRAY, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_identifyImage, 0, 0, 0)
-#endif
-
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, append_raw_output, _IS_BOOL, 0, "false")
-#else
-    ZEND_ARG_INFO(0, append_raw_output)
-#endif
-
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, append_raw_output, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_thresholdImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_thresholdImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, threshold)
-#endif
+	ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_adaptiveThresholdImage, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_adaptiveThresholdImage, 0, 0, 3)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, width)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, height)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, offset)
-#endif
+	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_blackThresholdImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_blackThresholdImage, 0, 0, 1)
-#endif
-
 	ZEND_ARG_OBJ_TYPE_MASK(0, threshold_color, ImagickPixel, MAY_BE_STRING, NULL)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_whiteThresholdImage arginfo_class_Imagick_blackThresholdImage
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_appendImages, 0, 1, Imagick, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_appendImages, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, stack, _IS_BOOL, 0)
-#else
-    ZEND_ARG_INFO(0, stack)
-#endif
+	ZEND_ARG_TYPE_INFO(0, stack, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_charcoalImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_charcoalImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, radius)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, sigma)
-#endif
+	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_normalizeImage, 0, 0, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_normalizeImage, 0, 0, 0)
-#endif
-
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
 #if MagickLibVersion >= 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_oilPaintImageWithSigma, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_oilPaintImageWithSigma, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, radius)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, sigma)
-#endif
+	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_oilPaintImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_oilPaintImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, radius)
-#endif
+	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_posterizeImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_posterizeImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, levels, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, levels)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, dither, _IS_BOOL, 0)
-#else
-    ZEND_ARG_INFO(0, dither)
-#endif
+	ZEND_ARG_TYPE_INFO(0, levels, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, dither, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_radialBlurImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_radialBlurImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, angle)
-#endif
+	ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_raiseImage, 0, 5, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_raiseImage, 0, 0, 5)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, width)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, height)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, x)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, y)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, raise, _IS_BOOL, 0)
-#else
-    ZEND_ARG_INFO(0, raise)
-#endif
+	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, raise, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_resampleImage, 0, 4, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_resampleImage, 0, 0, 4)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x_resolution, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, x_resolution)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, y_resolution, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, y_resolution)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, filter, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, filter)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, blur, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, blur)
-#endif
+	ZEND_ARG_TYPE_INFO(0, x_resolution, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, y_resolution, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, filter, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, blur, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_resizeImage, 0, 4, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_resizeImage, 0, 0, 4)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, columns)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, rows)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, filter, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, filter)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, blur, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, blur)
-#endif
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bestfit, _IS_BOOL, 0, "false")
-#else
-    ZEND_ARG_INFO(0, bestfit)
-#endif
-
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
-#else
-    ZEND_ARG_INFO(0, legacy)
-#endif
-
+	ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, filter, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, blur, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, bestfit, _IS_BOOL, 0, "false")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_rollImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_rollImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, x)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, y)
-#endif
+	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_rotateImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_rotateImage, 0, 0, 2)
-#endif
-
 	ZEND_ARG_OBJ_TYPE_MASK(0, background_color, ImagickPixel, MAY_BE_STRING, NULL)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, degrees, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, degrees)
-#endif
+	ZEND_ARG_TYPE_INFO(0, degrees, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_sampleImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_sampleImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, columns)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, rows)
-#endif
+	ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_solarizeImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_solarizeImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, threshold, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, threshold)
-#endif
+	ZEND_ARG_TYPE_INFO(0, threshold, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_shadowImage, 0, 4, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_shadowImage, 0, 0, 4)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, opacity, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, opacity)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, sigma)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, x)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, y)
-#endif
+	ZEND_ARG_TYPE_INFO(0, opacity, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageAttribute, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageAttribute, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, key)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, value)
-#endif
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageBackgroundColor, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageBackgroundColor, 0, 0, 1)
-#endif
-
 	ZEND_ARG_OBJ_TYPE_MASK(0, background_color, ImagickPixel, MAY_BE_STRING, NULL)
 ZEND_END_ARG_INFO()
 
 #if MagickLibVersion >= 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageChannelMask, 0, 1, IS_LONG, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageChannelMask, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, channel)
-#endif
+	ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageCompose, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageCompose, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, compose, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, compose)
-#endif
+	ZEND_ARG_TYPE_INFO(0, compose, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageDelay, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageDelay, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, delay, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, delay)
-#endif
+	ZEND_ARG_TYPE_INFO(0, delay, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageDepth, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageDepth, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, depth, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, depth)
-#endif
+	ZEND_ARG_TYPE_INFO(0, depth, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageGamma, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageGamma, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, gamma, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, gamma)
-#endif
+	ZEND_ARG_TYPE_INFO(0, gamma, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageIterations, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageIterations, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, iterations, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, iterations)
-#endif
+	ZEND_ARG_TYPE_INFO(0, iterations, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #if MagickLibVersion < 0x700 || MagickLibVersion >= 0x705
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageMatteColor, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageMatteColor, 0, 0, 1)
-#endif
-
 	ZEND_ARG_OBJ_TYPE_MASK(0, matte_color, ImagickPixel, MAY_BE_STRING, NULL)
 ZEND_END_ARG_INFO()
 #endif
@@ -2985,168 +977,53 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_Imagick_setImageProgressMonitor arginfo_class_Imagick_readImage
 
 #if MagickLibVersion > 0x653
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setProgressMonitor, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setProgressMonitor, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
-#else
-    ZEND_ARG_INFO(0, callback)
-#endif
+	ZEND_ARG_TYPE_INFO(0, callback, IS_CALLABLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageResolution, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageResolution, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x_resolution, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, x_resolution)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, y_resolution, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, y_resolution)
-#endif
+	ZEND_ARG_TYPE_INFO(0, x_resolution, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, y_resolution, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageScene, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageScene, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, scene, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, scene)
-#endif
+	ZEND_ARG_TYPE_INFO(0, scene, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageTicksPerSecond, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageTicksPerSecond, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, ticks_per_second, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, ticks_per_second)
-#endif
+	ZEND_ARG_TYPE_INFO(0, ticks_per_second, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageType, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageType, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, image_type, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, image_type)
-#endif
+	ZEND_ARG_TYPE_INFO(0, image_type, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageUnits, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageUnits, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, units, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, units)
-#endif
+	ZEND_ARG_TYPE_INFO(0, units, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_sharpenImage arginfo_class_Imagick_blurImage
 
 #define arginfo_class_Imagick_shaveImage arginfo_class_Imagick_sampleImage
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_shearImage, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_shearImage, 0, 0, 3)
-#endif
-
 	ZEND_ARG_OBJ_TYPE_MASK(0, background_color, ImagickPixel, MAY_BE_STRING, NULL)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x_shear, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, x_shear)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, y_shear, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, y_shear)
-#endif
+	ZEND_ARG_TYPE_INFO(0, x_shear, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, y_shear, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_spliceImage arginfo_class_Imagick_cropImage
 
 #define arginfo_class_Imagick_pingImage arginfo_class_Imagick_readImage
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_readImageFile, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_readImageFile, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, filehandle, IS_MIXED, 0)
-#else
-    ZEND_ARG_INFO(0, filehandle)
-#endif
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filename, IS_STRING, 1, "null")
-#else
-    ZEND_ARG_INFO(0, filename)
-#endif
-
+	ZEND_ARG_TYPE_INFO(0, filehandle, IS_MIXED, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, filename, IS_STRING, 1, "null")
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_displayImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_displayImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, servername, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, servername)
-#endif
+	ZEND_ARG_TYPE_INFO(0, servername, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_displayImages arginfo_class_Imagick_displayImage
@@ -3154,513 +1031,160 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_Imagick_spreadImage arginfo_class_Imagick_oilPaintImage
 
 #if MagickLibVersion >= 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_spreadImageWithMethod, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_spreadImageWithMethod, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, radius)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, interpolate_method, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, interpolate_method)
-#endif
+	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, interpolate_method, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_swirlImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_swirlImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, degrees, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, degrees)
-#endif
+	ZEND_ARG_TYPE_INFO(0, degrees, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 
 #if MagickLibVersion >= 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_swirlImageWithMethod, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_swirlImageWithMethod, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, degrees, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, degrees)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, interpolate_method, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, interpolate_method)
-#endif
+	ZEND_ARG_TYPE_INFO(0, degrees, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, interpolate_method, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #define arginfo_class_Imagick_stripImage arginfo_class_Imagick_removeImage
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_queryFormats, 0, 0, IS_ARRAY, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_queryFormats, 0, 0, 0)
-#endif
-
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, pattern, IS_STRING, 0, "\"*\"")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_queryFonts arginfo_class_Imagick_queryFormats
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_queryFontMetrics, 0, 2, IS_ARRAY, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_queryFontMetrics, 0, 0, 2)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, settings, ImagickDraw, 0)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, text, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, text)
-#endif
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, multiline, _IS_BOOL, 1, "null")
-#else
-    ZEND_ARG_INFO(0, multiline)
-#endif
-
+	ZEND_ARG_TYPE_INFO(0, text, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, multiline, _IS_BOOL, 1, "null")
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_steganoImage, 0, 2, Imagick, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_steganoImage, 0, 0, 2)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, watermark, Imagick, 0)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, offset)
-#endif
+	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_addNoiseImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_addNoiseImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, noise, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, noise)
-#endif
+	ZEND_ARG_TYPE_INFO(0, noise, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
 #if IM_HAVE_IMAGICK_ADD_NOISE_WITH_ATTENUATE
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_addNoiseImageWithAttenuate, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_addNoiseImageWithAttenuate, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, noise, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, noise)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, attenuate, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, attenuate)
-#endif
+	ZEND_ARG_TYPE_INFO(0, noise, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, attenuate, IS_DOUBLE, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_motionBlurImage, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_motionBlurImage, 0, 0, 3)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, radius)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, sigma)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, angle)
-#endif
+	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
 #if MagickLibVersion < 0x700 && !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_mosaicImages, 0, 0, Imagick, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_mosaicImages, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_morphImages, 0, 1, Imagick, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_morphImages, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, number_frames, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, number_frames)
-#endif
+	ZEND_ARG_TYPE_INFO(0, number_frames, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_minifyImage arginfo_class_Imagick_removeImage
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_affineTransformImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_affineTransformImage, 0, 0, 1)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, settings, ImagickDraw, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_averageImages arginfo_class_Imagick_clone
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_borderImage, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_borderImage, 0, 0, 3)
-#endif
-
 	ZEND_ARG_OBJ_TYPE_MASK(0, border_color, ImagickPixel, MAY_BE_STRING, NULL)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, width)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, height)
-#endif
+	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #if MagickLibVersion >= 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_borderImageWithComposite, 0, 4, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_borderImageWithComposite, 0, 0, 4)
-#endif
-
 	ZEND_ARG_OBJ_TYPE_MASK(0, border_color, ImagickPixel, MAY_BE_STRING, NULL)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, width)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, height)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, composite, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, composite)
-#endif
+	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, composite, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_calculateCrop, 0, 4, IS_ARRAY, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_calculateCrop, 0, 0, 4)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, original_width, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, original_width)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, original_height, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, original_height)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, desired_width, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, desired_width)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, desired_height, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, desired_height)
-#endif
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
-#else
-    ZEND_ARG_INFO(0, legacy)
-#endif
-
+	ZEND_ARG_TYPE_INFO(0, original_width, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, original_height, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, desired_width, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, desired_height, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_chopImage arginfo_class_Imagick_cropImage
 
 #define arginfo_class_Imagick_clipImage arginfo_class_Imagick_removeImage
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_clipPathImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_clipPathImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, pathname, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, pathname)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, inside, _IS_BOOL, 0)
-#else
-    ZEND_ARG_INFO(0, inside)
-#endif
+	ZEND_ARG_TYPE_INFO(0, pathname, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, inside, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_clipImagePath, 0, 2, IS_VOID, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_clipImagePath, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, pathname, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, pathname)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, inside, _IS_BOOL, 0)
-#else
-    ZEND_ARG_INFO(0, inside)
-#endif
+	ZEND_ARG_TYPE_INFO(0, pathname, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, inside, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_coalesceImages arginfo_class_Imagick_clone
 
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_colorFloodfillImage, 0, 5, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_colorFloodfillImage, 0, 0, 5)
-#endif
-
 	ZEND_ARG_OBJ_TYPE_MASK(0, fill_color, ImagickPixel, MAY_BE_STRING, NULL)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, fuzz)
-#endif
+	ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, border_color, ImagickPixel, MAY_BE_STRING, NULL)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, x)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, y)
-#endif
+	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_colorizeImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_colorizeImage, 0, 0, 2)
-#endif
-
 	ZEND_ARG_OBJ_TYPE_MASK(0, colorize_color, ImagickPixel, MAY_BE_STRING, NULL)
 	ZEND_ARG_OBJ_TYPE_MASK(0, opacity_color, ImagickPixel, MAY_BE_STRING|MAY_BE_FALSE, NULL)
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 1, "false")
-#else
-    ZEND_ARG_INFO(0, legacy)
-#endif
-
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 1, "false")
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_compareImageChannels, 0, 3, IS_ARRAY, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_compareImageChannels, 0, 0, 3)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, reference, Imagick, 0)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, channel)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, metric)
-#endif
+	ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_compareImages, 0, 2, IS_ARRAY, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_compareImages, 0, 0, 2)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, reference, Imagick, 0)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, metric)
-#endif
+	ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_contrastImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_contrastImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, sharpen, _IS_BOOL, 0)
-#else
-    ZEND_ARG_INFO(0, sharpen)
-#endif
+	ZEND_ARG_TYPE_INFO(0, sharpen, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_combineImages, 0, 1, Imagick, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_combineImages, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, colorspace)
-#endif
+	ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_convolveImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_convolveImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, kernel, IS_ARRAY, 0)
-#else
-    ZEND_ARG_INFO(0, kernel)
-#endif
+	ZEND_ARG_TYPE_INFO(0, kernel, IS_ARRAY, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_cycleColormapImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_cycleColormapImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, displace, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, displace)
-#endif
+	ZEND_ARG_TYPE_INFO(0, displace, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_deconstructImages arginfo_class_Imagick_clone
@@ -3675,42 +1199,15 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_equalizeImage arginfo_class_Imagick_removeImage
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_evaluateImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_evaluateImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, evaluate, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, evaluate)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, constant, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, constant)
-#endif
+	ZEND_ARG_TYPE_INFO(0, evaluate, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, constant, IS_DOUBLE, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
 #if MagickLibVersion >= 0x687
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_evaluateImages, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_evaluateImages, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, evaluate, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, evaluate)
-#endif
+	ZEND_ARG_TYPE_INFO(0, evaluate, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
@@ -3721,246 +1218,79 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_Imagick_flopImage arginfo_class_Imagick_removeImage
 
 #if MagickLibVersion >= 0x655
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_forwardFourierTransformImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_forwardFourierTransformImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, magnitude, _IS_BOOL, 0)
-#else
-    ZEND_ARG_INFO(0, magnitude)
-#endif
+	ZEND_ARG_TYPE_INFO(0, magnitude, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_frameImage, 0, 5, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_frameImage, 0, 0, 5)
-#endif
-
 	ZEND_ARG_OBJ_TYPE_MASK(0, matte_color, ImagickPixel, MAY_BE_STRING, NULL)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, width)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, height)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, inner_bevel, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, inner_bevel)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, outer_bevel, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, outer_bevel)
-#endif
+	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, inner_bevel, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, outer_bevel, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #if MagickLibVersion >= 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_frameImageWithComposite, 0, 6, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_frameImageWithComposite, 0, 0, 6)
-#endif
-
 	ZEND_ARG_OBJ_TYPE_MASK(0, matte_color, ImagickPixel, MAY_BE_STRING, NULL)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, width)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, height)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, inner_bevel, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, inner_bevel)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, outer_bevel, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, outer_bevel)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, composite, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, composite)
-#endif
+	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, inner_bevel, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, outer_bevel, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, composite, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_fxImage, 0, 1, Imagick, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_fxImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, expression, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, expression)
-#endif
+	ZEND_ARG_TYPE_INFO(0, expression, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_gammaImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_gammaImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, gamma, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, gamma)
-#endif
+	ZEND_ARG_TYPE_INFO(0, gamma, IS_DOUBLE, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_gaussianBlurImage arginfo_class_Imagick_blurImage
 
 #if MagickLibVersion < 0x700 && !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageAttribute, 0, 1, IS_STRING, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageAttribute, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, key)
-#endif
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getImageBackgroundColor, 0, 0, ImagickPixel, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageBackgroundColor, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageBluePrimary arginfo_class_Imagick_getImageGeometry
 
 #define arginfo_class_Imagick_getImageBorderColor arginfo_class_Imagick_getImageBackgroundColor
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageChannelDepth, 0, 1, IS_LONG, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageChannelDepth, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, channel)
-#endif
+	ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageChannelDistortion, 0, 3, IS_DOUBLE, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageChannelDistortion, 0, 0, 3)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, reference, Imagick, 0)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, channel)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, metric)
-#endif
+	ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageChannelExtrema, 0, 1, IS_ARRAY, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageChannelExtrema, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, channel)
-#endif
+	ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageChannelMean, 0, 1, IS_ARRAY, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageChannelMean, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, channel)
-#endif
+	ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageChannelStatistics arginfo_class_Imagick_getImageGeometry
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getImageColormapColor, 0, 1, ImagickPixel, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageColormapColor, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, index)
-#endif
+	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageColorspace arginfo_class_Imagick_getImageSize
@@ -3971,42 +1301,19 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageDepth arginfo_class_Imagick_getImageSize
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageDistortion, 0, 2, IS_DOUBLE, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageDistortion, 0, 0, 2)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, reference, Imagick, 0)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, metric)
-#endif
+	ZEND_ARG_TYPE_INFO(0, metric, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageExtrema, 0, 0, IS_ARRAY, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageExtrema, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #define arginfo_class_Imagick_getImageDispose arginfo_class_Imagick_getImageSize
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageGamma, 0, 0, IS_DOUBLE, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageGamma, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageGreenPrimary arginfo_class_Imagick_getImageGeometry
@@ -4020,76 +1327,27 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_Imagick_getImageIterations arginfo_class_Imagick_getImageSize
 
 #if MagickLibVersion < 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getImageMatteColor, 0, 0, ImagickPixel, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageMatteColor, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #define arginfo_class_Imagick_getImagePage arginfo_class_Imagick_getImageGeometry
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getImagePixelColor, 0, 2, ImagickPixel, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImagePixelColor, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, x)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, y)
-#endif
+	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #if IM_HAVE_IMAGICK_SETIMAGEPIXELCOLOR
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_setImagePixelColor, 0, 3, ImagickPixel, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImagePixelColor, 0, 0, 3)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, x)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, y)
-#endif
+	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, color, ImagickPixel, MAY_BE_STRING, NULL)
 ZEND_END_ARG_INFO()
 #endif
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageProfile, 0, 1, IS_STRING, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageProfile, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, name)
-#endif
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageRedPrimary arginfo_class_Imagick_getImageGeometry
@@ -4118,743 +1376,230 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageTotalInkDensity arginfo_class_Imagick_getImageGamma
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getImageRegion, 0, 4, Imagick, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageRegion, 0, 0, 4)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, width)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, height)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, x)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, y)
-#endif
+	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_implodeImage arginfo_class_Imagick_oilPaintImage
 
 #if MagickLibVersion >= 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_implodeImageWithMethod, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_implodeImageWithMethod, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, radius)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, pixel_interpolate_method, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, pixel_interpolate_method)
-#endif
+	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, pixel_interpolate_method, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion >= 0x658
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_inverseFourierTransformImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_inverseFourierTransformImage, 0, 0, 2)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, complement, Imagick, 0)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, magnitude, _IS_BOOL, 0)
-#else
-    ZEND_ARG_INFO(0, magnitude)
-#endif
+	ZEND_ARG_TYPE_INFO(0, magnitude, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_levelImage, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_levelImage, 0, 0, 3)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, black_point, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, black_point)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, gamma, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, gamma)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, white_point, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, white_point)
-#endif
+	ZEND_ARG_TYPE_INFO(0, black_point, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, gamma, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, white_point, IS_DOUBLE, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_magnifyImage arginfo_class_Imagick_removeImage
 
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_mapImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_mapImage, 0, 0, 2)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, map, imagick, 0)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, dither, _IS_BOOL, 0)
-#else
-    ZEND_ARG_INFO(0, dither)
-#endif
+	ZEND_ARG_TYPE_INFO(0, dither, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_matteFloodfillImage, 0, 5, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_matteFloodfillImage, 0, 0, 5)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, alpha, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, alpha)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, fuzz)
-#endif
+	ZEND_ARG_TYPE_INFO(0, alpha, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, border_color, ImagickPixel, MAY_BE_STRING, NULL)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, x)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, y)
-#endif
+	ZEND_ARG_TYPE_INFO(0, x, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, y, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion < 0x700 && !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_medianFilterImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_medianFilterImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, radius)
-#endif
+	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_negateImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_negateImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, gray, _IS_BOOL, 0)
-#else
-    ZEND_ARG_INFO(0, gray)
-#endif
+	ZEND_ARG_TYPE_INFO(0, gray, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_paintOpaqueImage, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_paintOpaqueImage, 0, 0, 3)
-#endif
-
 	ZEND_ARG_OBJ_TYPE_MASK(0, target_color, ImagickPixel, MAY_BE_STRING, NULL)
 	ZEND_ARG_OBJ_TYPE_MASK(0, fill_color, ImagickPixel, MAY_BE_STRING, NULL)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, fuzz)
-#endif
+	ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_paintTransparentImage, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_paintTransparentImage, 0, 0, 3)
-#endif
-
 	ZEND_ARG_OBJ_TYPE_MASK(0, target_color, ImagickPixel, MAY_BE_STRING, NULL)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, alpha, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, alpha)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, fuzz)
-#endif
+	ZEND_ARG_TYPE_INFO(0, alpha, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, fuzz, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_previewImages, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_previewImages, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, preview, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, preview)
-#endif
+	ZEND_ARG_TYPE_INFO(0, preview, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_profileImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_profileImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, name)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, profile, IS_STRING, 1)
-#else
-    ZEND_ARG_INFO(0, profile)
-#endif
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, profile, IS_STRING, 1)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_quantizeImage, 0, 5, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_quantizeImage, 0, 0, 5)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, number_colors, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, number_colors)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, colorspace)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, tree_depth, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, tree_depth)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, dither, _IS_BOOL, 0)
-#else
-    ZEND_ARG_INFO(0, dither)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, measure_error, _IS_BOOL, 0)
-#else
-    ZEND_ARG_INFO(0, measure_error)
-#endif
+	ZEND_ARG_TYPE_INFO(0, number_colors, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, tree_depth, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, dither, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, measure_error, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_quantizeImages arginfo_class_Imagick_quantizeImage
 
 #if !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_reduceNoiseImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_reduceNoiseImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, radius)
-#endif
+	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #define arginfo_class_Imagick_removeImageProfile arginfo_class_Imagick_getImageProfile
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_separateImageChannel, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_separateImageChannel, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, channel)
-#endif
+	ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_sepiaToneImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_sepiaToneImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, threshold)
-#endif
+	ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 
 #if MagickLibVersion < 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageBias, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageBias, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, bias, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, bias)
-#endif
+	ZEND_ARG_TYPE_INFO(0, bias, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion < 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageBiasQuantum, 0, 1, IS_VOID, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageBiasQuantum, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, bias, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, bias)
-#endif
+	ZEND_ARG_TYPE_INFO(0, bias, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageBluePrimary, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageBluePrimary, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, x, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, x)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, y, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, y)
-#endif
+	ZEND_ARG_TYPE_INFO(0, x, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, y, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageBorderColor, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageBorderColor, 0, 0, 1)
-#endif
-
 	ZEND_ARG_OBJ_TYPE_MASK(0, border_color, ImagickPixel, MAY_BE_STRING, NULL)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageChannelDepth, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageChannelDepth, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, channel)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, depth, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, depth)
-#endif
+	ZEND_ARG_TYPE_INFO(0, channel, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, depth, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageColormapColor, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageColormapColor, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, index)
-#endif
+	ZEND_ARG_TYPE_INFO(0, index, IS_LONG, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, color, ImagickPixel, MAY_BE_STRING, NULL)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageColorspace, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageColorspace, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, colorspace)
-#endif
+	ZEND_ARG_TYPE_INFO(0, colorspace, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageDispose, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageDispose, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, dispose, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, dispose)
-#endif
+	ZEND_ARG_TYPE_INFO(0, dispose, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_setImageExtent arginfo_class_Imagick_sampleImage
 
 #define arginfo_class_Imagick_setImageGreenPrimary arginfo_class_Imagick_setImageBluePrimary
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageInterlaceScheme, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageInterlaceScheme, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, interlace, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, interlace)
-#endif
+	ZEND_ARG_TYPE_INFO(0, interlace, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageProfile, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageProfile, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, name)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, profile, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, profile)
-#endif
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, profile, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_setImageRedPrimary arginfo_class_Imagick_setImageBluePrimary
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageRenderingIntent, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageRenderingIntent, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, rendering_intent, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, rendering_intent)
-#endif
+	ZEND_ARG_TYPE_INFO(0, rendering_intent, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageVirtualPixelMethod, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageVirtualPixelMethod, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, method, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, method)
-#endif
+	ZEND_ARG_TYPE_INFO(0, method, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_setImageWhitePoint arginfo_class_Imagick_setImageBluePrimary
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_sigmoidalContrastImage, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_sigmoidalContrastImage, 0, 0, 3)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, sharpen, _IS_BOOL, 0)
-#else
-    ZEND_ARG_INFO(0, sharpen)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, alpha, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, alpha)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, beta, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, beta)
-#endif
+	ZEND_ARG_TYPE_INFO(0, sharpen, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, alpha, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, beta, IS_DOUBLE, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_stereoImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_stereoImage, 0, 0, 1)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, offset_image, Imagick, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_textureImage, 0, 1, Imagick, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_textureImage, 0, 0, 1)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, texture, Imagick, 0)
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_tintImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_tintImage, 0, 0, 2)
-#endif
-
 	ZEND_ARG_OBJ_TYPE_MASK(0, tint_color, ImagickPixel, MAY_BE_STRING, NULL)
 	ZEND_ARG_OBJ_TYPE_MASK(0, opacity_color, ImagickPixel, MAY_BE_STRING, NULL)
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
-#else
-    ZEND_ARG_INFO(0, legacy)
-#endif
-
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, legacy, _IS_BOOL, 0, "false")
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_unsharpMaskImage, 0, 4, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_unsharpMaskImage, 0, 0, 4)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, radius)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, sigma)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, amount, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, amount)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, threshold)
-#endif
+	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, amount, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImage arginfo_class_Imagick_clone
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_addImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_addImage, 0, 0, 1)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, image, Imagick, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_setImage arginfo_class_Imagick_addImage
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_newImage, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_newImage, 0, 0, 3)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, columns)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, rows)
-#endif
+	ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
 	ZEND_ARG_OBJ_TYPE_MASK(0, background_color, ImagickPixel, MAY_BE_STRING, NULL)
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, format, IS_STRING, 0, "null")
-#else
-    ZEND_ARG_INFO(0, format)
-#endif
-
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, format, IS_STRING, 0, "null")
 ZEND_END_ARG_INFO()
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_newPseudoImage, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_newPseudoImage, 0, 0, 3)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, columns)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, rows)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, pseudo_format, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, pseudo_format)
-#endif
+	ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, pseudo_format, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getCompression arginfo_class_Imagick_getImageSize
@@ -4866,13 +1611,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_Imagick_getConfigureOptions arginfo_class_Imagick_queryFormats
 
 #if MagickLibVersion > 0x660
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getFeatures, 0, 0, IS_STRING, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getFeatures, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
@@ -4884,19 +1623,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getInterlaceScheme arginfo_class_Imagick_getImageSize
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getOption, 0, 1, IS_STRING, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getOption, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, key)
-#endif
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getPackageName arginfo_class_Imagick___toString
@@ -4913,19 +1641,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getReleaseDate arginfo_class_Imagick___toString
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getResource, 0, 1, IS_LONG, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getResource, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, type)
-#endif
+	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getResourceLimit arginfo_class_Imagick_getResource
@@ -4948,82 +1665,28 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_setInterlaceScheme arginfo_class_Imagick_setImageInterlaceScheme
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setOption, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setOption, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, key)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, value)
-#endif
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_setPage arginfo_class_Imagick_cropImage
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setResourceLimit, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setResourceLimit, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, type)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, limit, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, limit)
-#endif
+	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, limit, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_setResolution arginfo_class_Imagick_setImageResolution
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setSamplingFactors, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setSamplingFactors, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, factors, IS_ARRAY, 0)
-#else
-    ZEND_ARG_INFO(0, factors)
-#endif
+	ZEND_ARG_TYPE_INFO(0, factors, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_setSize arginfo_class_Imagick_sampleImage
 
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setType, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setType, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, imgtype, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, imgtype)
-#endif
+	ZEND_ARG_TYPE_INFO(0, imgtype, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 #if MagickLibVersion > 0x628
@@ -5044,166 +1707,56 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_current, 0, 0, Imagick, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_current, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && MagickLibVersion >= 0x659
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_brightnessContrastImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_brightnessContrastImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, brightness, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, brightness)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, contrast, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, contrast)
-#endif
+	ZEND_ARG_TYPE_INFO(0, brightness, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, contrast, IS_DOUBLE, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && MagickLibVersion > 0x661
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_colorMatrixImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_colorMatrixImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, color_matrix, IS_ARRAY, 0)
-#else
-    ZEND_ARG_INFO(0, color_matrix)
-#endif
+	ZEND_ARG_TYPE_INFO(0, color_matrix, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_selectiveBlurImage, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_selectiveBlurImage, 0, 0, 3)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, radius)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, sigma)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, threshold)
-#endif
+	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && MagickLibVersion >= 0x689
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_rotationalBlurImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_rotationalBlurImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, angle)
-#endif
+	ZEND_ARG_TYPE_INFO(0, angle, IS_DOUBLE, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && MagickLibVersion >= 0x683
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_statisticImage, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_statisticImage, 0, 0, 3)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, type)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, width)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, height)
-#endif
+	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && MagickLibVersion >= 0x652
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_subimageMatch, 0, 1, Imagick, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_subimageMatch, 0, 0, 1)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, image, Imagick, 0)
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(1, offset, IS_ARRAY, 1, "null")
-#else
-    ZEND_ARG_INFO(1, offset)
-#endif
-
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(1, similarity, IS_DOUBLE, 1, "null")
-#else
-    ZEND_ARG_INFO(1, similarity)
-#endif
-
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(1, offset, IS_ARRAY, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(1, similarity, IS_DOUBLE, 1, "null")
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, threshold, IS_DOUBLE, 0, "0.0")
-
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, metric, IS_LONG, 0, "0")
-#else
-    ZEND_ARG_INFO(0, metric)
-#endif
-
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, metric, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 #endif
 
@@ -5212,108 +1765,42 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setRegistry, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setRegistry, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, key)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, value)
-#endif
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getRegistry, 0, 1, IS_STRING, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getRegistry, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, key)
-#endif
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_listRegistry, 0, 0, IS_ARRAY, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_listRegistry, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && MagickLibVersion >= 0x680
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_morphology, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_morphology, 0, 0, 3)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, morphology, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, morphology)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, iterations, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, iterations)
-#endif
+	ZEND_ARG_TYPE_INFO(0, morphology, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, iterations, IS_LONG, 0)
 	ZEND_ARG_OBJ_INFO(0, kernel, ImagickKernel, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_DEFAULT")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && defined(IMAGICK_WITH_KERNEL) && MagickLibVersion < 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_filter, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_filter, 0, 0, 1)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, kernel, ImagickKernel, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 0, "Imagick::CHANNEL_UNDEFINED")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setAntialias, 0, 1, IS_VOID, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setAntialias, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, antialias, _IS_BOOL, 0)
-#else
-    ZEND_ARG_INFO(0, antialias)
-#endif
+	ZEND_ARG_TYPE_INFO(0, antialias, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 #endif
 
@@ -5322,53 +1809,24 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && MagickLibVersion > 0x676
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_colorDecisionListImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_colorDecisionListImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, color_correction_collection, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, color_correction_collection)
-#endif
+	ZEND_ARG_TYPE_INFO(0, color_correction_collection, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && MagickLibVersion >= 0x687
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_optimizeImageTransparency, 0, 0, IS_VOID, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_optimizeImageTransparency, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && MagickLibVersion >= 0x660
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_autoGammaImage, 0, 0, IS_VOID, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_autoGammaImage, 0, 0, 0)
-#endif
-
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, channel, IS_LONG, 1, "Imagick::CHANNEL_ALL")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_autoOrient, 0, 0, IS_VOID, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_autoOrient, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
@@ -5377,716 +1835,248 @@ ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && MagickLibVersion >= 0x692
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_compositeImageGravity, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_compositeImageGravity, 0, 0, 3)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, image, Imagick, 0)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, composite_constant, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, composite_constant)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, gravity, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, gravity)
-#endif
+	ZEND_ARG_TYPE_INFO(0, composite_constant, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, gravity, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && MagickLibVersion >= 0x693
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_localContrastImage, 0, 2, IS_VOID, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_localContrastImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, radius)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, strength, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, strength)
-#endif
+	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, strength, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && MagickLibVersion >= 0x700
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_identifyImageType, 0, 0, IS_LONG, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_identifyImageType, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GETSETIMAGEMASK
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getImageMask, 0, 1, Imagick, 1)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageMask, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, pixelmask, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, pixelmask)
-#endif
+	ZEND_ARG_TYPE_INFO(0, pixelmask, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GETSETIMAGEMASK
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setImageMask, 0, 2, IS_VOID, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setImageMask, 0, 0, 2)
-#endif
-
 	ZEND_ARG_OBJ_INFO(0, clip_mask, Imagick, 0)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, pixelmask, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, pixelmask)
-#endif
+	ZEND_ARG_TYPE_INFO(0, pixelmask, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && MagickLibVersion >= 0x709
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_cannyEdgeImage, 0, 4, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_cannyEdgeImage, 0, 0, 4)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, radius)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, sigma)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, lower_percent, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, lower_percent)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, upper_percent, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, upper_percent)
-#endif
+	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, lower_percent, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, upper_percent, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SETSEED
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setSeed, 0, 1, IS_VOID, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setSeed, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, seed, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, seed)
-#endif
+	ZEND_ARG_TYPE_INFO(0, seed, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_WAVELETDENOISEIMAGE
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_waveletDenoiseImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_waveletDenoiseImage, 0, 0, 2)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, threshold)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, softness, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, softness)
-#endif
+	ZEND_ARG_TYPE_INFO(0, threshold, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, softness, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_MEANSHIFTIMAGE
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_meanShiftImage, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_meanShiftImage, 0, 0, 3)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, width)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, height)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, color_distance, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, color_distance)
-#endif
+	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, color_distance, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_KMEANSIMAGE
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_kmeansImage, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_kmeansImage, 0, 0, 3)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, number_colors, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, number_colors)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, max_iterations, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, max_iterations)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, tolerance, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, tolerance)
-#endif
+	ZEND_ARG_TYPE_INFO(0, number_colors, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, max_iterations, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, tolerance, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_RANGETHRESHOLDIMAGE
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_rangeThresholdImage, 0, 4, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_rangeThresholdImage, 0, 0, 4)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, low_black, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, low_black)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, low_white, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, low_white)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, high_white, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, high_white)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, high_black, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, high_black)
-#endif
+	ZEND_ARG_TYPE_INFO(0, low_black, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, low_white, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, high_white, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, high_black, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_AUTOTHRESHOLDIMAGE
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_autoThresholdImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_autoThresholdImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, auto_threshold_method, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, auto_threshold_method)
-#endif
+	ZEND_ARG_TYPE_INFO(0, auto_threshold_method, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_BILATERALBLURIMAGE
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_bilateralBlurImage, 0, 4, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_bilateralBlurImage, 0, 0, 4)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, radius)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, sigma)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, intensity_sigma, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, intensity_sigma)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, spatial_sigma, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, spatial_sigma)
-#endif
+	ZEND_ARG_TYPE_INFO(0, radius, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, sigma, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, intensity_sigma, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, spatial_sigma, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_CLAHEIMAGE
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_claheImage, 0, 4, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_claheImage, 0, 0, 4)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, width)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, height)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, number_bins, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, number_bins)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, clip_limit, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, clip_limit)
-#endif
+	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, height, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, number_bins, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, clip_limit, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_CHANNELFXIMAGE
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_channelFxImage, 0, 1, Imagick, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_channelFxImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, expression, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, expression)
-#endif
+	ZEND_ARG_TYPE_INFO(0, expression, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_COLORTHRESHOLDIMAGE
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_colorThresholdImage, 0, 2, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_colorThresholdImage, 0, 0, 2)
-#endif
-
 	ZEND_ARG_OBJ_TYPE_MASK(0, start_color, ImagickPixel, MAY_BE_STRING, NULL)
 	ZEND_ARG_OBJ_TYPE_MASK(0, stop_color, ImagickPixel, MAY_BE_STRING, NULL)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_COMPLEXIMAGES
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_complexImages, 0, 1, Imagick, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_complexImages, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, complex_operator, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, complex_operator)
-#endif
+	ZEND_ARG_TYPE_INFO(0, complex_operator, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_INTERPOLATIVERESIZEIMAGE
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_interpolativeResizeImage, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_interpolativeResizeImage, 0, 0, 3)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, columns)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, rows)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, interpolate, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, interpolate)
-#endif
+	ZEND_ARG_TYPE_INFO(0, columns, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, rows, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, interpolate, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_LEVELIMAGECOLORS
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_levelImageColors, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_levelImageColors, 0, 0, 3)
-#endif
-
 	ZEND_ARG_OBJ_TYPE_MASK(0, black_color, ImagickPixel, MAY_BE_STRING, NULL)
 	ZEND_ARG_OBJ_TYPE_MASK(0, white_color, ImagickPixel, MAY_BE_STRING, NULL)
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, invert, _IS_BOOL, 0)
-#else
-    ZEND_ARG_INFO(0, invert)
-#endif
+	ZEND_ARG_TYPE_INFO(0, invert, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_LEVELIZEIMAGE
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_levelizeImage, 0, 3, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_levelizeImage, 0, 0, 3)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, black_point, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, black_point)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, gamma, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, gamma)
-#endif
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, white_point, IS_DOUBLE, 0)
-#else
-    ZEND_ARG_INFO(0, white_point)
-#endif
+	ZEND_ARG_TYPE_INFO(0, black_point, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, gamma, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, white_point, IS_DOUBLE, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_ORDEREDDITHERIMAGE
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_orderedDitherImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_orderedDitherImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, dither_format, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, dither_format)
-#endif
+	ZEND_ARG_TYPE_INFO(0, dither_format, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_WHITEBALANCEIMAGE
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_whiteBalanceImage, 0, 0, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_whiteBalanceImage, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_DELETE_OPTION
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_deleteOption, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_deleteOption, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, option, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, option)
-#endif
+	ZEND_ARG_TYPE_INFO(0, option, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_BACKGROUND_COLOR
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_Imagick_getBackgroundColor, 0, 0, ImagickPixel, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getBackgroundColor, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_ARTIFACTS
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageArtifacts, 0, 0, IS_ARRAY, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageArtifacts, 0, 0, 0)
-#endif
-
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, pattern, IS_STRING, 0, "\"*\"")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_KURTOSIS
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageKurtosis, 0, 0, IS_ARRAY, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageKurtosis, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_MEAN
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageMean, 0, 0, IS_ARRAY, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageMean, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_IMAGE_RANGE
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageRange, 0, 0, IS_ARRAY, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageRange, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_INTERPOLATE_METHOD
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getInterpolateMethod, 0, 0, IS_LONG, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getInterpolateMethod, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_OPTIONS
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getOptions, 0, 0, IS_ARRAY, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getOptions, 0, 0, 0)
-#endif
-
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, pattern, IS_STRING, 0, "\"*\"")
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_ORIENTATION
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getOrientation, 0, 0, IS_LONG, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getOrientation, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_RESOLUTION
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getResolution, 0, 0, IS_ARRAY, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getResolution, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_GET_TYPE
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getType, 0, 0, IS_LONG, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getType, 0, 0, 0)
-#endif
-
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_POLYNOMIAL_IMAGE
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_polynomialImage, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_polynomialImage, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, terms, IS_ARRAY, 0)
-#else
-    ZEND_ARG_INFO(0, terms)
-#endif
+	ZEND_ARG_TYPE_INFO(0, terms, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_DEPTH
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setDepth, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setDepth, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, depth, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, depth)
-#endif
+	ZEND_ARG_TYPE_INFO(0, depth, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_EXTRACT
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setExtract, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setExtract, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, geometry, IS_STRING, 0)
-#else
-    ZEND_ARG_INFO(0, geometry)
-#endif
+	ZEND_ARG_TYPE_INFO(0, geometry, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_INTERPOLATE_METHOD
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setInterpolateMethod, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setInterpolateMethod, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, method, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, method)
-#endif
+	ZEND_ARG_TYPE_INFO(0, method, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
 #if MagickLibVersion > 0x628 && IM_HAVE_IMAGICK_SET_ORIENTATION
-
-#if PHP_VERSION_ID >= 80000
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_setOrientation, 0, 1, _IS_BOOL, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_setOrientation, 0, 0, 1)
-#endif
-
-	
-#if PHP_VERSION_ID >= 80000
-    ZEND_ARG_TYPE_INFO(0, orientation, IS_LONG, 0)
-#else
-    ZEND_ARG_INFO(0, orientation)
-#endif
+	ZEND_ARG_TYPE_INFO(0, orientation, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 #endif
 
@@ -6222,6 +2212,9 @@ ZEND_METHOD(Imagick, paintFloodfillImage);
 #endif
 #if MagickLibVersion > 0x635
 ZEND_METHOD(Imagick, clutImage);
+#endif
+#if MagickLibVersion > 0x635 && MagickLibVersion > 0x700
+ZEND_METHOD(Imagick, clutImageWithInterpolate);
 #endif
 #if MagickLibVersion > 0x635
 ZEND_METHOD(Imagick, getImageProperties);
@@ -6880,85 +2873,38 @@ ZEND_METHOD(Imagick, setOrientation);
 #endif
 
 
+#if MagickLibVersion > 0x628
 static const zend_function_entry class_Imagick_methods[] = {
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, optimizeImageLayers, arginfo_class_Imagick_optimizeImageLayers, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, compareImageLayers, arginfo_class_Imagick_compareImageLayers, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, pingImageBlob, arginfo_class_Imagick_pingImageBlob, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, pingImageFile, arginfo_class_Imagick_pingImageFile, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, transposeImage, arginfo_class_Imagick_transposeImage, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, transverseImage, arginfo_class_Imagick_transverseImage, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, trimImage, arginfo_class_Imagick_trimImage, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, waveImage, arginfo_class_Imagick_waveImage, ZEND_ACC_PUBLIC)
-#endif
 #if MagickLibVersion > 0x628 && MagickLibVersion >= 0x700
 	ZEND_ME(Imagick, waveImageWithMethod, arginfo_class_Imagick_waveImageWithMethod, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, vignetteImage, arginfo_class_Imagick_vignetteImage, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, uniqueImageColors, arginfo_class_Imagick_uniqueImageColors, ZEND_ACC_PUBLIC)
-#endif
 #if MagickLibVersion > 0x628 && !defined(MAGICKCORE_EXCLUDE_DEPRECATED) && MagickLibVersion < 0x700
 	ZEND_ME(Imagick, getImageMatte, arginfo_class_Imagick_getImageMatte, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
 #endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, setImageMatte, arginfo_class_Imagick_setImageMatte, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, adaptiveResizeImage, arginfo_class_Imagick_adaptiveResizeImage, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, sketchImage, arginfo_class_Imagick_sketchImage, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, shadeImage, arginfo_class_Imagick_shadeImage, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, getSizeOffset, arginfo_class_Imagick_getSizeOffset, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, setSizeOffset, arginfo_class_Imagick_setSizeOffset, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, adaptiveBlurImage, arginfo_class_Imagick_adaptiveBlurImage, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, contrastStretchImage, arginfo_class_Imagick_contrastStretchImage, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, adaptiveSharpenImage, arginfo_class_Imagick_adaptiveSharpenImage, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, randomThresholdImage, arginfo_class_Imagick_randomThresholdImage, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, roundCornersImage, arginfo_class_Imagick_roundCornersImage, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_MALIAS(Imagick, roundCorners, roundCornersImage, arginfo_class_Imagick_roundCorners, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, setIteratorIndex, arginfo_class_Imagick_setIteratorIndex, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, getIteratorIndex, arginfo_class_Imagick_getIteratorIndex, ZEND_ACC_PUBLIC)
-#endif
 #if MagickLibVersion > 0x628 && MagickLibVersion < 0x700
 	ZEND_ME(Imagick, transformImage, arginfo_class_Imagick_transformImage, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
 #endif
@@ -7015,6 +2961,9 @@ static const zend_function_entry class_Imagick_methods[] = {
 #endif
 #if MagickLibVersion > 0x635
 	ZEND_ME(Imagick, clutImage, arginfo_class_Imagick_clutImage, ZEND_ACC_PUBLIC)
+#endif
+#if MagickLibVersion > 0x635 && MagickLibVersion > 0x700
+	ZEND_ME(Imagick, clutImageWithInterpolate, arginfo_class_Imagick_clutImageWithInterpolate, ZEND_ACC_PUBLIC)
 #endif
 #if MagickLibVersion > 0x635
 	ZEND_ME(Imagick, getImageProperties, arginfo_class_Imagick_getImageProperties, ZEND_ACC_PUBLIC)
@@ -7496,30 +3445,18 @@ static const zend_function_entry class_Imagick_methods[] = {
 	ZEND_ME(Imagick, setSamplingFactors, arginfo_class_Imagick_setSamplingFactors, ZEND_ACC_PUBLIC)
 	ZEND_ME(Imagick, setSize, arginfo_class_Imagick_setSize, ZEND_ACC_PUBLIC)
 	ZEND_ME(Imagick, setType, arginfo_class_Imagick_setType, ZEND_ACC_PUBLIC)
-#if MagickLibVersion > 0x628
 	ZEND_MALIAS(Imagick, key, getIteratorIndex, arginfo_class_Imagick_key, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_MALIAS(Imagick, next, nextImage, arginfo_class_Imagick_next, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_MALIAS(Imagick, rewind, setFirstIterator, arginfo_class_Imagick_rewind, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, valid, arginfo_class_Imagick_valid, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, current, arginfo_class_Imagick_current, ZEND_ACC_PUBLIC)
-#endif
 #if MagickLibVersion > 0x628 && MagickLibVersion >= 0x659
 	ZEND_ME(Imagick, brightnessContrastImage, arginfo_class_Imagick_brightnessContrastImage, ZEND_ACC_PUBLIC)
 #endif
 #if MagickLibVersion > 0x628 && MagickLibVersion > 0x661
 	ZEND_ME(Imagick, colorMatrixImage, arginfo_class_Imagick_colorMatrixImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, selectiveBlurImage, arginfo_class_Imagick_selectiveBlurImage, ZEND_ACC_PUBLIC)
-#endif
 #if MagickLibVersion > 0x628 && MagickLibVersion >= 0x689
 	ZEND_ME(Imagick, rotationalBlurImage, arginfo_class_Imagick_rotationalBlurImage, ZEND_ACC_PUBLIC)
 #endif
@@ -7532,27 +3469,17 @@ static const zend_function_entry class_Imagick_methods[] = {
 #if MagickLibVersion > 0x628 && MagickLibVersion >= 0x652
 	ZEND_MALIAS(Imagick, similarityImage, subimageMatch, arginfo_class_Imagick_similarityImage, ZEND_ACC_PUBLIC)
 #endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, setRegistry, arginfo_class_Imagick_setRegistry, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, getRegistry, arginfo_class_Imagick_getRegistry, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, listRegistry, arginfo_class_Imagick_listRegistry, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-#endif
 #if MagickLibVersion > 0x628 && MagickLibVersion >= 0x680
 	ZEND_ME(Imagick, morphology, arginfo_class_Imagick_morphology, ZEND_ACC_PUBLIC)
 #endif
 #if MagickLibVersion > 0x628 && defined(IMAGICK_WITH_KERNEL) && MagickLibVersion < 0x700
 	ZEND_ME(Imagick, filter, arginfo_class_Imagick_filter, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
 #endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, setAntialias, arginfo_class_Imagick_setAntialias, ZEND_ACC_PUBLIC)
-#endif
-#if MagickLibVersion > 0x628
 	ZEND_ME(Imagick, getAntialias, arginfo_class_Imagick_getAntialias, ZEND_ACC_PUBLIC)
-#endif
 #if MagickLibVersion > 0x628 && MagickLibVersion > 0x676
 	ZEND_ME(Imagick, colorDecisionListImage, arginfo_class_Imagick_colorDecisionListImage, ZEND_ACC_PUBLIC)
 #endif
@@ -7684,3 +3611,4 @@ static const zend_function_entry class_Imagick_methods[] = {
 #endif
 	ZEND_FE_END
 };
+#endif

--- a/imagick_class.c
+++ b/imagick_class.c
@@ -6570,7 +6570,7 @@ PHP_METHOD(Imagick, enhanceImage)
 
 	/* No magick is going to happen */
 	if (status == MagickFalse) {
-		php_imagick_convert_imagick_exception(intern->magick_wand, "Unable to enchance image" TSRMLS_CC);
+		php_imagick_convert_imagick_exception(intern->magick_wand, "Unable to enhance image" TSRMLS_CC);
 		return;
 	}
 

--- a/imagick_class.c
+++ b/imagick_class.c
@@ -1392,6 +1392,47 @@ PHP_METHOD(Imagick, clutImage)
 }
 /* }}} */
 
+
+
+/* {{{ proto Imagick Imagick::clutImageWithInterpolate(Imagick lookup, int pixel_interpolate_method)
+   Replaces colors in the image from a color lookup table.
+*/
+PHP_METHOD(Imagick, clutImageWithInterpolate)
+{
+	zval *objvar;
+	php_imagick_object *intern, *lookup;
+	MagickBooleanType status;
+	im_long interpolate_method;
+
+	/* Parse parameters given to function */
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Ol", &objvar, php_imagick_sc_entry, &interpolate_method) == FAILURE) {
+		return;
+	}
+
+	intern = Z_IMAGICK_P(getThis());
+	if (php_imagick_ensure_not_empty (intern->magick_wand) == 0)
+		return;
+
+	lookup = Z_IMAGICK_P(objvar);
+	if (php_imagick_ensure_not_empty (lookup->magick_wand) == 0)
+		return;
+
+	status = MagickClutImage(intern->magick_wand, lookup->magick_wand, interpolate_method);
+
+	/* No magick is going to happen */
+	if (status == MagickFalse) {
+		php_imagick_convert_imagick_exception(
+			intern->magick_wand,
+			"Unable to replace colors in the image from a color lookup table" TSRMLS_CC
+		);
+		return;
+	}
+
+	RETURN_TRUE;
+}
+/* }}} */
+
+
 /* {{{ proto Imagick Imagick::getImageProperties([string pattern, bool values] )
   	Returns all the property names that match the specified pattern
 */

--- a/imagick_class.c
+++ b/imagick_class.c
@@ -8644,16 +8644,17 @@ PHP_METHOD(Imagick, getImageBlob)
 
 	intern = Z_IMAGICK_P(getThis());
 	if (php_imagick_ensure_not_empty (intern->magick_wand) == 0)
-		return;
+		RETURN_THROWS();
 
 	if (!s_image_has_format (intern->magick_wand)) {
 		php_imagick_throw_exception(IMAGICK_CLASS, "Image has no format" TSRMLS_CC);
-		return;
+		RETURN_THROWS();
 	}
 
 	image_contents = MagickGetImageBlob(intern->magick_wand, &image_size);
 	if (!image_contents) {
-		return;
+		php_imagick_throw_exception(IMAGICK_CLASS, "Failed to get the image contents (empty or invalid image?)" TSRMLS_CC);
+		RETURN_THROWS();
 	}
 
 	IM_ZVAL_STRINGL(return_value, (char *)image_contents, image_size);

--- a/imagick_class.c
+++ b/imagick_class.c
@@ -1393,7 +1393,7 @@ PHP_METHOD(Imagick, clutImage)
 /* }}} */
 
 
-
+#if MagickLibVersion >= 0x700
 /* {{{ proto Imagick Imagick::clutImageWithInterpolate(Imagick lookup, int pixel_interpolate_method)
    Replaces colors in the image from a color lookup table.
 */
@@ -1431,7 +1431,7 @@ PHP_METHOD(Imagick, clutImageWithInterpolate)
 	RETURN_TRUE;
 }
 /* }}} */
-
+#endif
 
 /* {{{ proto Imagick Imagick::getImageProperties([string pattern, bool values] )
   	Returns all the property names that match the specified pattern

--- a/imagick_helpers.c
+++ b/imagick_helpers.c
@@ -1279,6 +1279,11 @@ void php_imagick_initialize_constants(TSRMLS_D)
 	IMAGICK_REGISTER_CONST_LONG("COMPRESSION_WEBP", WebPCompression);
 #endif
 
+#if MagickLibVersion >= 0x711
+    IMAGICK_REGISTER_CONST_LONG("COMPRESSION_BC5", BC5Compression);
+    IMAGICK_REGISTER_CONST_LONG("COMPRESSION_BC7", BC7Compression);
+#endif
+
 #if MagickLibVersion >= 0x70C
 	IMAGICK_REGISTER_CONST_LONG("COMPRESSION_DWAA", DWAACompression);
 	IMAGICK_REGISTER_CONST_LONG("COMPRESSION_DWAB", DWABCompression);

--- a/imagickdraw_class.c
+++ b/imagickdraw_class.c
@@ -1616,9 +1616,16 @@ PHP_METHOD(ImagickDraw, setStrokeDashArray)
 	php_imagickdraw_object *internd;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a", &param_array) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a!", &param_array) == FAILURE) {
 		return;
 	}
+
+    internd = Z_IMAGICKDRAW_P(getThis());
+
+    if (param_array == NULL) {
+        DrawSetStrokeDashArray(internd->drawing_wand, 0, NULL);
+    	RETURN_TRUE;
+    }
 
 	double_array = php_imagick_zval_to_double_array(param_array, &elements TSRMLS_CC);
 
@@ -1626,8 +1633,6 @@ PHP_METHOD(ImagickDraw, setStrokeDashArray)
 		php_imagick_throw_exception(IMAGICKDRAW_CLASS, "Cannot read stroke dash array parameter" TSRMLS_CC);
 		return;
 	}
-
-	internd = Z_IMAGICKDRAW_P(getThis());
 
 	DrawSetStrokeDashArray(internd->drawing_wand, elements, double_array);
 	efree(double_array);

--- a/package.xml
+++ b/package.xml
@@ -117,6 +117,7 @@ This extension requires ImageMagick version 6.5.3-10+ and PHP 5.4.0+.
 				<file name="040_Imagick_charcoalImage_basic.phpt" role="test" />
 				<file name="041_Imagick_chopImage_basic.phpt" role="test" />
 				<file name="042_Imagick_clutImage_basic.phpt" role="test" />
+				<file name="042_Imagick_clutImage_im7.phpt" role="test" />
 				<file name="043_Imagick_colorizeImage_basic.phpt" role="test" />
 				<file name="044_Imagick_colorMatrixImage_basic.phpt" role="test" />
 				<file name="045_Imagick_compositeImage_basic.phpt" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -396,6 +396,7 @@ This extension requires ImageMagick version 6.5.3-10+ and PHP 5.4.0+.
 				<file name="326_Imagick_setExtract.phpt" role="test" />
 				<file name="327_Imagick_polaroidImage_basic.phpt" role="test" />
 				<file name="328_Imagick_polaroidImageWithTextAndMethod_basic.phpt" role="test" />
+				<file name="329_imagick_getImageBlob_empty.phpt" role="test" />
 				<file name="bug20636.phpt" role="test" />
 				<file name="bug21229.phpt" role="test" />
 				<file name="bug59378.phpt" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -274,7 +274,7 @@ This extension requires ImageMagick version 6.5.3-10+ and PHP 5.4.0+.
 				<file name="164_Imagick_trimImage_basic.phpt" role="test" />
 				<file name="165_Imagick_unsharpMaskImage_basic.phpt" role="test" />
 				<file name="166_Imagick_waveImage_basic.phpt" role="test" />
-				<file name="166_Imagick_waveImageWithMethod_basic.phpt"  />
+				<file name="166_Imagick_waveImageWithMethod_basic.phpt" role="test" />
 				<file name="167_Imagick_vignetteImage_basic.phpt" role="test" />
 				<file name="168_Imagick_whiteThresholdImage_basic.phpt" role="test" />
 				<file name="169_ImagickPixel_construct_basic.phpt" role="test" />

--- a/package.xml
+++ b/package.xml
@@ -13,55 +13,19 @@ This extension requires ImageMagick version 6.5.3-10+ and PHP 5.4.0+.
 		<email>danack@php.net</email>
 		<active>yes</active>
 	</lead>
-	<date>2022-01-04</date>
+	<date>2022-01-11</date>
 	<version>
-		<release>3.7.0RC1</release>
-		<api>3.7.0RC1</api>
+		<release>3.7.0</release>
+		<api>3.7.0</api>
 	</version>
 	<stability>
-		<release>beta</release>
-		<api>beta</api>
+		<release>stable</release>
+		<api>stable</api>
 	</stability>
 	<license uri="http://www.php.net/license">PHP License</license>
 <notes>
 - Added:
-  * function Imagick::deleteOption(string $option): bool {}
-  * function Imagick::getBackgroundColor(): ImagickPixel {}
-  * function Imagick::getImageArtifacts(string $pattern = "*"): array {}
-  * function Imagick::getImageKurtosis(): array {}
-  * function Imagick::getImageMean(): array {}
-  * function Imagick::getImageRange(): array {}
-  * function Imagick::getInterpolateMethod(): int {}
-  * function Imagick::getOptions(string $pattern = "*"): array {}
-  * function Imagick::getOrientation(): int {}
-  * function Imagick::getResolution(): array {}
-  * function Imagick::getType(): int {}
-  * function Imagick::implodeImageWithMethod(float $radius, int $pixel_interpolate_method): bool  {}
-  * function Imagick::oilPaintImageWithSigma(float $radius, float $sigma)
-  * function Imagick::polaroidWithTextAndMethod(ImagickDraw $settings, float $angle, string $caption, int $method): bool {}
-  * function Imagick::polynomialImage(array $terms): bool {}
-  * function Imagick::setDepth(int $depth): bool {}
-  * function Imagick::setExtract(string $geometry): bool {}
-  * function Imagick::setInterpolateMethod(int $method): bool{}
-  * function Imagick::setOrientation(int $orientation): bool {}
-  * function Imagick::spreadImageWithMethod(float $radius, int $interpolate_method): bool  {}
-  * function Imagick::swirlImageWithMethod(float $degrees, int $interpolate_method): bool  {}
-  * function Imagick::waveImageWithMethod(float $amplitude, float $length, int $interpolate_method): bool {}
-  * Imagick::IMAGE_TYPE_BILEVEL
-  * Imagick::IMAGE_TYPE_GRAYSCALE
-  * Imagick::IMAGE_TYPE_GRAYSCALE_ALPHA
-  * Imagick::IMAGE_TYPE_PALETTE
-  * Imagick::IMAGE_TYPE_PALETTE_ALPHA
-  * Imagick::IMAGE_TYPE_TRUE_COLOR
-  * Imagick::IMAGE_TYPE_TRUE_COLOR_ALPHA
-  * Imagick::IMAGE_TYPE_COLOR_SEPARATION
-  * Imagick::IMAGE_TYPE_COLOR_SEPARATION_ALPHA
-  * Imagick::IMAGE_TYPE_OPTIMIZE
-  * Imagick::IMAGE_TYPE_PALETTE_BILEVEL_ALPHA
-  * Imagick::COMPOSITE_SEAMLESS_BLEND
-- Changed:
-  * Imagick::setImageArtifact can now take null for the string value.
-  * Return type for Imagick::getImageArtifact is string|null instead of string.
+	* Imagick::COMPOSITE_SALIENCY_BLEND
 </notes>
 	<contents>
 		<dir name="/">

--- a/package.xml
+++ b/package.xml
@@ -274,7 +274,7 @@ This extension requires ImageMagick version 6.5.3-10+ and PHP 5.4.0+.
 				<file name="164_Imagick_trimImage_basic.phpt" role="test" />
 				<file name="165_Imagick_unsharpMaskImage_basic.phpt" role="test" />
 				<file name="166_Imagick_waveImage_basic.phpt" role="test" />
-				<file name="166_Imagick_waveImageWithMethod_basic.phpt" role="test"  />
+				<file name="166_Imagick_waveImageWithMethod_basic.phpt"  />
 				<file name="167_Imagick_vignetteImage_basic.phpt" role="test" />
 				<file name="168_Imagick_whiteThresholdImage_basic.phpt" role="test" />
 				<file name="169_ImagickPixel_construct_basic.phpt" role="test" />

--- a/runDev.sh
+++ b/runDev.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+
+
+
+DOCKER_SCAN_SUGGEST=false BUILDKIT_PROGRESS=plain docker-compose up --build developing

--- a/shim_im6_to_im7.c
+++ b/shim_im6_to_im7.c
@@ -181,18 +181,24 @@ MagickBooleanType MagickClampImageChannel(MagickWand *wand, const ChannelType ch
 	}
 
 	return status;
-
 }
 
-MagickBooleanType MagickClutImageChannel(MagickWand *wand, const ChannelType channel, const MagickWand *clut_wand) {
+MagickBooleanType MagickClutImageChannel(
+	MagickWand *wand,
+	const ChannelType channel,
+	const MagickWand *clut_wand
+) {
 	MagickBooleanType status;
 	ChannelType previous_channel_mask;
 
 	if (channel != UndefinedChannel) {
 		previous_channel_mask = MagickSetImageChannelMask(wand, channel);
 	}
-	//TODO - need to take parameter
-	status = MagickClutImage(wand, clut_wand, AverageInterpolatePixel);
+
+	PixelInterpolateMethod pixelInterpolateMethod;
+
+	pixelInterpolateMethod = MagickGetInterpolateMethod(wand);
+	status = MagickClutImage(wand, clut_wand, pixelInterpolateMethod);
 
 	if (channel != UndefinedChannel) {
 		(void) MagickSetImageChannelMask(wand, previous_channel_mask);

--- a/shim_im6_to_im7.c
+++ b/shim_im6_to_im7.c
@@ -190,12 +190,11 @@ MagickBooleanType MagickClutImageChannel(
 ) {
 	MagickBooleanType status;
 	ChannelType previous_channel_mask;
+	PixelInterpolateMethod pixelInterpolateMethod;
 
 	if (channel != UndefinedChannel) {
 		previous_channel_mask = MagickSetImageChannelMask(wand, channel);
 	}
-
-	PixelInterpolateMethod pixelInterpolateMethod;
 
 	pixelInterpolateMethod = MagickGetInterpolateMethod(wand);
 	status = MagickClutImage(wand, clut_wand, pixelInterpolateMethod);

--- a/tests/042_Imagick_clutImage_basic.phpt
+++ b/tests/042_Imagick_clutImage_basic.phpt
@@ -45,7 +45,9 @@ $gradient->setImageFormat('png');
 
 $imagick->setImageFormat('png');
 
-$imagick->setInterpolateMethod(Imagick::INTERPOLATE_BILINEAR);
+// This test is for IM < 7 so setInterpolate not available
+// Which probably means the clutImage method isn't usuable...
+//$imagick->setInterpolateMethod(Imagick::INTERPOLATE_BILINEAR);
 $imagick->clutImage($gradient);
 
 $bytes = $imagick->getImageBlob();

--- a/tests/042_Imagick_clutImage_basic.phpt
+++ b/tests/042_Imagick_clutImage_basic.phpt
@@ -8,20 +8,50 @@ require_once(dirname(__FILE__) . '/skipif.inc');
 --FILE--
 <?php
 
+$draw = new \ImagickDraw();
+$draw->setStrokeOpacity(0);
+$draw->setFillColor('black');
+$points = [
+	['x' => 40 * 3, 'y' => 10 * 5],
+	['x' => 20 * 3, 'y' => 20 * 5],
+	['x' => 70 * 3, 'y' => 50 * 5],
+	['x' => 80 * 3, 'y' => 15 * 5],
+];
+$draw->polygon($points);
+$imagick = new \Imagick();
 
-function clutImage() {
-    $imagick = new \Imagick();
-    $imagick->newPseudoImage(640, 480, "magick:logo");
-    //$imagick->quantizeImage(16, \Imagick::COLORSPACE_YIQ, 8, true, false);
-    
-    $clutImagick = new \Imagick();
-    $clutImagick->newPseudoImage(640, 480, "magick:NETSCAPE");
-    $imagick->clutImage($clutImagick);
-    $bytes = $imagick->getImageBlob();
-    if (strlen($bytes) <= 0) { echo "Failed to generate image.";} 
-}
+$imagick->setColorspace(\Imagick::COLORSPACE_GRAY);
 
-clutImage() ;
+$imagick->newPseudoImage(
+	300, 300,
+	"xc:white"
+);
+
+$imagick->drawImage($draw);
+$imagick->blurImage(0, 10);
+
+$draw = new \ImagickDraw();
+$draw->setStrokeOpacity(1);
+$draw->setFillColor('red');
+$draw->point(0, 2);
+$draw->setFillColor('yellow');
+$draw->rectangle(0, 0, 1, 1);
+$gradient = new Imagick();
+$gradient->newPseudoImage(1, 5, 'xc:black');
+$gradient->drawImage($draw);
+$gradient->setImageFormat('png');
+
+
+
+$imagick->setImageFormat('png');
+
+$imagick->setInterpolateMethod(Imagick::INTERPOLATE_BILINEAR);
+$imagick->clutImage($gradient);
+
+$bytes = $imagick->getImageBlob();
+if (strlen($bytes) <= 0) { echo "Failed to generate image.";}
+
+
 echo "Ok";
 ?>
 --EXPECTF--

--- a/tests/042_Imagick_clutImage_im7.phpt
+++ b/tests/042_Imagick_clutImage_im7.phpt
@@ -1,0 +1,59 @@
+--TEST--
+Test Imagick, clutImageWithInterpolate
+--SKIPIF--
+<?php
+
+require_once(dirname(__FILE__) . '/skipif.inc');
+
+checkClassMethods('Imagick', array('clutImageWithInterpolate'));
+
+?>
+--FILE--
+<?php
+
+$draw = new \ImagickDraw();
+$draw->setStrokeOpacity(0);
+$draw->setFillColor('black');
+$points = [
+	['x' => 40 * 3, 'y' => 10 * 5],
+	['x' => 20 * 3, 'y' => 20 * 5],
+	['x' => 70 * 3, 'y' => 50 * 5],
+	['x' => 80 * 3, 'y' => 15 * 5],
+];
+$draw->polygon($points);
+$imagick = new \Imagick();
+
+$imagick->setColorspace(\Imagick::COLORSPACE_GRAY);
+
+$imagick->newPseudoImage(
+	300, 300,
+	"xc:white"
+);
+
+
+$imagick->drawImage($draw);
+$imagick->blurImage(0, 10);
+
+$draw = new \ImagickDraw();
+$draw->setStrokeOpacity(1);
+$draw->setFillColor('red');
+$draw->point(0, 2);
+$draw->setFillColor('yellow');
+$draw->rectangle(0, 0, 1, 1);
+$gradient = new Imagick();
+$gradient->newPseudoImage(1, 5, 'xc:black');
+$gradient->drawImage($draw);
+
+
+$imagick->setImageFormat('png');
+$imagick->clutImageWithInterpolate($gradient, Imagick::INTERPOLATE_BILINEAR);
+
+$bytes = $imagick->getImageBlob();
+if (strlen($bytes) <= 0) { echo "Failed to generate image.";}
+
+// $imagick->writeImage(__DIR__ . "/feels_bad_man.png");
+
+echo "Ok";
+?>
+--EXPECTF--
+Ok

--- a/tests/329_imagick_getImageBlob_empty.phpt
+++ b/tests/329_imagick_getImageBlob_empty.phpt
@@ -10,14 +10,14 @@ $imagick = new Imagick();
 try {
     $imagick->newPseudoImage(200, 200, "xc:red");
 	$result = $imagick->getImageBlob();
-	echo "Imagick failed to throw exception";
+	echo "Imagick failed to throw exception" . PHP_EOL;
 } catch (ImagickException $e) {
-	echo "ImagickException: " . $e->getMessage();
+	echo "ImagickException: " . $e->getMessage() . PHP_EOL;
 }
 
 echo "Fin.\n";
 
 ?>
 --EXPECTF--
-ImagickException: Some words here.
+ImagickException: Failed to get the image contents (empty or invalid image?)
 Fin.

--- a/tests/329_imagick_getImageBlob_empty.phpt
+++ b/tests/329_imagick_getImageBlob_empty.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Imagick::getImageBlob behaviour on invalid images
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+// Fails due to image having no format
+$imagick = new Imagick();
+try {
+    $imagick->newPseudoImage(200, 200, "xc:red");
+	$result = $imagick->getImageBlob();
+	echo "Imagick failed to throw exception";
+} catch (ImagickException $e) {
+	echo "ImagickException: " . $e->getMessage();
+}
+
+echo "Fin.\n";
+
+?>
+--EXPECTF--
+ImagickException: Some words here.
+Fin.

--- a/validate_package.sh
+++ b/validate_package.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+VALIDATE_OUTPUT=`pear package-validate`
+
+echo "VALIDATE_OUTPUT is $VALIDATE_OUTPUT"
+
+if [[ "$VALIDATE_OUTPUT" == *"Error"* ]]; then
+  echo "Package appears to contain an error"
+  exit 255
+fi
+
+echo "Package appears valid"


### PR DESCRIPTION
The signature of the function tells us that getImageBlob() always returns a string or throws Exception.

In this case, the returning value is NULL as retval is unset.