### PR TITLE
Return void according to the function signatures

### DIFF
--- a/imagick_class.c
+++ b/imagick_class.c
@@ -8267,7 +8267,7 @@ PHP_METHOD(Imagick, cropThumbnailImage)
 }
 /* }}} */
 
-/* {{{ proto bool Imagick::resetIterator();
+/* {{{ proto void Imagick::resetIterator();
 	Resets the iterator.  Use it in conjunction with Imagick::nextImage() to iterate over all the images in a wand container.
 */
 PHP_METHOD(Imagick, resetIterator)
@@ -8281,11 +8281,10 @@ PHP_METHOD(Imagick, resetIterator)
 
 	/* No magick is going to happen */
 	if (intern->magick_wand == NULL) {
-		RETURN_FALSE;
+		return;
 	}
 	intern->next_out_of_bound = 0;
 	MagickResetIterator(intern->magick_wand);
-	RETURN_TRUE;
 }
 /* }}} */
 
@@ -13155,7 +13154,7 @@ PHP_METHOD(Imagick, filter)
 #endif //#if MagickLibVersion < 0x700
 #endif // #ifdef IMAGICK_WITH_KERNEL
 
-/* {{{ proto int Imagick::setAntiAlias(bool antialias)
+/* {{{ proto void Imagick::setAntiAlias(bool antialias)
 	Set whether antialiasing should be used for operations. On by default.
 */
 PHP_METHOD(Imagick, setAntialias)
@@ -13176,8 +13175,6 @@ PHP_METHOD(Imagick, setAntialias)
 		php_imagick_convert_imagick_exception(intern->magick_wand, "Unable to setAntiAlias" TSRMLS_CC);
 		return;
 	}
-
-	RETURN_TRUE;
 }
 /* }}} */
 
@@ -13258,8 +13255,6 @@ PHP_METHOD(Imagick, optimizeImageTransparency)
 		php_imagick_convert_imagick_exception(intern->magick_wand, "Optimize image transparency failed" TSRMLS_CC);
 		return;
 	}
-
-	RETURN_TRUE;
 }
 /* }}} */
 #endif
@@ -13289,8 +13284,6 @@ PHP_METHOD(Imagick, autoGammaImage)
 		php_imagick_convert_imagick_exception(intern->magick_wand, "autoGammaImage" TSRMLS_CC);
 		return;
 	}
-
-	RETURN_TRUE;
 }
 /* }}} */
 #endif //#if MagickLibVersion >= 0x660
@@ -13319,8 +13312,6 @@ PHP_METHOD(Imagick, autoOrient)
 		php_imagick_convert_imagick_exception(intern->magick_wand, "Unable autoOrient image" TSRMLS_CC);
 		return;
 	}
-
-	RETURN_TRUE;
 }
 /* }}} */
 #endif // #if MagickLibVersion >= 0x692
@@ -13363,7 +13354,7 @@ PHP_METHOD(Imagick, compositeImageGravity)
 #endif
 
 #if MagickLibVersion >= 0x693
-/* {{{ proto bool Imagick::localContrastImage(float radius, float strength)
+/* {{{ proto void Imagick::localContrastImage(float radius, float strength)
 Attempts to increase the appearance of large-scale light-dark transitions. 
 Local contrast enhancement works similarly to sharpening with an unsharp mask,
 however the mask is instead created using an image with a greater blur distance.
@@ -13390,8 +13381,6 @@ PHP_METHOD(Imagick, localContrastImage)
 		php_imagick_convert_imagick_exception(intern->magick_wand, "Failed to localContrastImage" TSRMLS_CC);
 		return;
 	}
-
-	RETURN_TRUE;
 }
 /* }}} */
 #endif // #if MagickLibVersion >= 0x693
@@ -13492,8 +13481,6 @@ PHP_METHOD(Imagick, setImageMask)
 	//	You want ei->severity. ei->error_number
 	// the Go Imagick library does something like:
 	//return &MagickWandException{ExceptionType(C.int(et)), C.GoString(csdescription)}
-
-	RETURN_TRUE;
 }
 /* }}} */
 #endif // IM_HAVE_IMAGICK_GETSETIMAGEMASK

--- a/imagickpixeliterator_class.c
+++ b/imagickpixeliterator_class.c
@@ -116,7 +116,6 @@ PHP_METHOD(ImagickPixelIterator, resetIterator)
 #if MagickLibVersion <= 0x628
 	internpix->iterator_position = 0;
 #endif
-	RETURN_TRUE;
 }
 /* }}} */
 


### PR DESCRIPTION
The following functions return void according to their signature in the stub-files but the code returns `bool`.
Again, that makes noise when PHP built with debug flags