### PR TITLE
Imagick::getResourceLimit() returns int, not double

### DIFF
--- a/imagick_class.c
+++ b/imagick_class.c
@@ -12111,7 +12111,7 @@ PHP_METHOD(Imagick, getResource)
 }
 /* }}} */
 
-/* {{{ proto Imagick Imagick::getResourceLimit(int type)
+/* {{{ proto int Imagick::getResourceLimit(int type)
 	Returns the specified resource limit in megabytes.
 */
 PHP_METHOD(Imagick, getResourceLimit)
@@ -12122,7 +12122,7 @@ PHP_METHOD(Imagick, getResourceLimit)
 		return;
 	}
 
-	RETVAL_DOUBLE(MagickGetResourceLimit(resource_type));
+	RETVAL_LONG(MagickGetResourceLimit(resource_type));
 }
 /* }}} */
 


### PR DESCRIPTION
`MagickGetResourceLimit` seems to return an integer and the signature in the stub-file also claims `int`