### PR TITLE
Release memory in Imagick::getConfigureOptions()

### DIFF
--- a/imagick_class.c
+++ b/imagick_class.c
@@ -14384,7 +14384,9 @@ PHP_METHOD(Imagick, getOptions)
 		option_value = MagickGetOption(intern->magick_wand, options[i]);
 		IM_add_assoc_string(return_value, options[i], option_value);
 		MagickRelinquishMemory(option_value);
+		DestroyString(options[i]);
 	}
+	RelinquishMagickMemory(options);
 
 	return;
 }

--- a/imagick_class.c
+++ b/imagick_class.c
@@ -11812,7 +11812,10 @@ PHP_METHOD(Imagick, getConfigureOptions)
 	for (i=0; i<number_options; i++) {
 		option_value = MagickQueryConfigureOption(result[i]);
 		IM_add_assoc_string(return_value, result[i], option_value);
+		DestroyString(result[i]);
+		DestroyString(option_value);
 	}
+	RelinquishMagickMemory(result);
 }
 /* }}} */
 


### PR DESCRIPTION
A few memleaks reported by ASAN.

it seems like `MagickQueryConfigureOptions()` returns not-constant memory and we will have to clean that up

```
$ ZEND_DONT_UNLOAD_MODULES=1 ./tests/254_getConfigureOptions.sh
Ok
==24023==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 182504 byte(s) in 44 object(s) allocated from:
    #0 0x7f53e933fbb8 in __interceptor_malloc (/lib64/libasan.so.5+0xefbb8)
    #1 0x7f53e3b2c436 in AcquireString MagickCore/string.c:107

Direct leak of 688 byte(s) in 2 object(s) allocated from:
    #0 0x7f53e933fbb8 in __interceptor_malloc (/lib64/libasan.so.5+0xefbb8)
    #1 0x7f53e39e1c89 in GetConfigureList MagickCore/configure.c:554

Indirect leak of 480 byte(s) in 44 object(s) allocated from:
    #0 0x7f53e933fbb8 in __interceptor_malloc (/lib64/libasan.so.5+0xefbb8)
    #1 0x7f53e3b2cb93 in ConstantString MagickCore/string.c:691

SUMMARY: AddressSanitizer: 183672 byte(s) leaked in 90 allocation(s).
```