### PR TITLE
Release memory in Imagick::getImageArtifacts()

### DIFF
--- a/imagick_class.c
+++ b/imagick_class.c
@@ -14221,8 +14221,11 @@ PHP_METHOD(Imagick, getImageArtifacts)
 		else {
 			IM_add_assoc_string(return_value, artifacts[i], artifact_value);
 			MagickRelinquishMemory(artifact_value);
+			DestroyString(artifact_value);
 		}
+		DestroyString(artifacts[i]);
 	}
+	RelinquishMagickMemory(artifacts);
 }
 /* }}} */
 #endif


### PR DESCRIPTION
It seems pretty similar to #600 but it's another method and I decided to split it into separated PR, just in case. 
Will be happy to merge them, if you prefer
```
$ ZEND_DONT_UNLOAD_MODULES=1 ./tests/315_Imagick_getImageArtifacts.sh
Ok
=================================================================
==2891804==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 8192 byte(s) in 1 object(s) allocated from:
    #0 0x7f7607a64bb8 in __interceptor_malloc (/lib64/libasan.so.5+0xefbb8)
    #1 0x7f76027b1b0d in MagickGetImageArtifacts MagickWand/magick-property.c:622
    #2 0x7f7602b52613 in zim_Imagick_getImageArtifacts /home/mgalanin/php-build/github.com-mkoppanen-imagick/imagick_class.c:14197
    #3 0xd3438d in ZEND_DO_FCALL_SPEC_RETVAL_USED_HANDLER /home/mgalanin/php-build/php-sources/Zend/zend_vm_execute.h:1863
    #4 0xe7687e in execute_ex /home/mgalanin/php-build/php-sources/Zend/zend_vm_execute.h:55195
    #5 0xe83e40 in zend_execute /home/mgalanin/php-build/php-sources/Zend/zend_vm_execute.h:59523
    #6 0xca0a4d in zend_execute_scripts /home/mgalanin/php-build/php-sources/Zend/zend.c:1826
    #7 0xb309dc in php_execute_script /home/mgalanin/php-build/php-sources/main/main.c:2568
    #8 0xf1b6ff in do_cli /home/mgalanin/php-build/php-sources/sapi/cli/php_cli.c:949
    #9 0xf1d9dc in main /home/mgalanin/php-build/php-sources/sapi/cli/php_cli.c:1341
    #10 0x7f76064afd84 in __libc_start_main (/lib64/libc.so.6+0x3ad84)

Indirect leak of 878 byte(s) in 48 object(s) allocated from:
    #0 0x7f7607a64bb8 in __interceptor_malloc (/lib64/libasan.so.5+0xefbb8)
    #1 0x7f760223a823 in ConstantString MagickCore/string.c:691

SUMMARY: AddressSanitizer: 9070 byte(s) leaked in 49 allocation(s).

```