### PR TITLE
Get image blob return empty string

### DIFF
--- a/imagick_class.c
+++ b/imagick_class.c
@@ -8644,16 +8644,17 @@ PHP_METHOD(Imagick, getImageBlob)
 
 	intern = Z_IMAGICK_P(getThis());
 	if (php_imagick_ensure_not_empty (intern->magick_wand) == 0)
-		return;
+		RETURN_THROWS();
 
 	if (!s_image_has_format (intern->magick_wand)) {
 		php_imagick_throw_exception(IMAGICK_CLASS, "Image has no format" TSRMLS_CC);
-		return;
+		RETURN_THROWS();
 	}
 
 	image_contents = MagickGetImageBlob(intern->magick_wand, &image_size);
 	if (!image_contents) {
-		return;
+		php_imagick_throw_exception(IMAGICK_CLASS, "Failed to get the image contents (empty or invalid image?)" TSRMLS_CC);
+		RETURN_THROWS();
 	}
 
 	IM_ZVAL_STRINGL(return_value, (char *)image_contents, image_size);

--- a/package.xml
+++ b/package.xml
@@ -396,6 +396,7 @@ This extension requires ImageMagick version 6.5.3-10+ and PHP 5.4.0+.
 				<file name="326_Imagick_setExtract.phpt" role="test" />
 				<file name="327_Imagick_polaroidImage_basic.phpt" role="test" />
 				<file name="328_Imagick_polaroidImageWithTextAndMethod_basic.phpt" role="test" />
+				<file name="329_imagick_getImageBlob_empty.phpt" role="test" />
 				<file name="bug20636.phpt" role="test" />
 				<file name="bug21229.phpt" role="test" />
 				<file name="bug59378.phpt" role="test" />

--- a/tests/329_imagick_getImageBlob_empty.phpt
+++ b/tests/329_imagick_getImageBlob_empty.phpt
@@ -10,14 +10,14 @@ $imagick = new Imagick();
 try {
     $imagick->newPseudoImage(200, 200, "xc:red");
 	$result = $imagick->getImageBlob();
-	echo "Imagick failed to throw exception";
+	echo "Imagick failed to throw exception" . PHP_EOL;
 } catch (ImagickException $e) {
-	echo "ImagickException: " . $e->getMessage();
+	echo "ImagickException: " . $e->getMessage() . PHP_EOL;
 }
 
 echo "Fin.\n";
 
 ?>
 --EXPECTF--
-ImagickException: Some words here.
+ImagickException: Failed to get the image contents (empty or invalid image?)
 Fin.

--- a/tests/329_imagick_getImageBlob_empty.phpt
+++ b/tests/329_imagick_getImageBlob_empty.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Imagick::getImageBlob behaviour on invalid images
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+// Fails due to image having no format
+$imagick = new Imagick();
+try {
+    $imagick->newPseudoImage(200, 200, "xc:red");
+	$result = $imagick->getImageBlob();
+	echo "Imagick failed to throw exception";
+} catch (ImagickException $e) {
+	echo "ImagickException: " . $e->getMessage();
+}
+
+echo "Fin.\n";
+
+?>
+--EXPECTF--
+ImagickException: Some words here.
+Fin.


### PR DESCRIPTION
This PR is instead of #588, against the proper branch.
* * * 


The signature of the function tells us that getImageBlob() always returns a string or throws an Exception.

In this case, the returning value is NULL as retval is unset.