### PR TITLE
Fix installation error "Unterminated preprocessor conditions" in php 8.3

### DIFF
--- a/Imagick.stub.php
+++ b/Imagick.stub.php
@@ -1669,4 +1669,5 @@ proto bool Imagick::setImageBluePrimary(float x, float y, float z) */
 	public function setOrientation(int $orientation): bool {}
 #endif
 
+#endif
 }


### PR DESCRIPTION
The first if condition in `Imagick.stub.php` is not closed
https://github.com/Imagick/imagick/blob/28f27044e435a2b203e32675e942eb8de620ee58/Imagick.stub.php#L5-L8

This causes a installation error "Unterminated preprocessor conditions" in PHP 8.3

Resolves #640 

Edit: this branch uses the wrong parent (it starts from master instead of 3.7.0) furthermore the endif I added is technically in wrong position (the correct one is commented here https://github.com/Imagick/imagick/blob/52ec37ff633de0e5cca159a6437b8c340afe7831/Imagick.stub.php#L1249), but *I think is ok to use this patch* because it keep the same 3.7.0 logics (everything after line https://github.com/Imagick/imagick/blob/52ec37ff633de0e5cca159a6437b8c340afe7831/Imagick.stub.php#L1236 is inside the if that in 3.7.0 is not closed).  

If you want to use it I suggest to get the diff file and apply it directly to the 3.7.0 code (you can download it runtime even with pecl and apply the patch).  

Anyway this should not be merged in master, I'll keep this open just to keep this problem in evidence