### PR TITLE
getResourceLimit might return a float

### DIFF
--- a/Imagick.stub.php
+++ b/Imagick.stub.php
@@ -1220,7 +1220,7 @@ proto bool Imagick::setImageBluePrimary(float x, float y, float z) */
 
     public static function getResource(int $type): int  {}
 
-    public static function getResourceLimit(int $type): int  {}
+    public static function getResourceLimit(int $type): int|float  {}
 
     public function getSamplingFactors(): array  {}
 


### PR DESCRIPTION
When passing Imagick::RESOURCETYPE_THREAD, the return type might also be a float.