### PR TITLE
Fix compatibility with php 8.4 and newer ImageMagick library versions 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 5.4 ]
+        php: [ 8.1 ]
         imagemagick: [
-            7.1.0-13,
-            6.9.2-0,
+          7.1.1-41,
+          6.9.2-0
         ]
 
     steps:
@@ -80,48 +80,21 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        php: [5.4, 8.1, 8.0, 7.4, 7.3, 7.2, 7.1, 7.0, 5.6, 5.5]
+        php: [8.4, 8.3, 8.2, 8.1, 7.4, 5.6]
         imagemagick: [
-          7.1.0-13,
-          7.0.10-27,
-          7.0.8-4,
+          7.1.1-41,
+          7.1.0-62,
+          7.0.11-14,
           7.0.1-0,
           git7,
           6.9.2-0,
           6.8.7-0,
           6.7.8-0,
-          git6
         ]
         exclude:
-          - php: 5.4
-            imagemagick: 6.8.7-0
-          - php: 7.4
-            imagemagick: git6
-          - php: 7.3
-            imagemagick: git6
-          - php: 7.2
-            imagemagick: git6
-          - php: 7.1
-            imagemagick: git6
-          - php: 7.0
-            imagemagick: git6
-          - php: 5.6
-            imagemagick: git6
-          - php: 5.5
-            imagemagick: git6
           - php: 7.4
             imagemagick: git7
-          - php: 7.3
-            imagemagick: git7
-          - php: 7.2
-            imagemagick: git7
-          - php: 7.1
-            imagemagick: git7
-          - php: 7.0
-            imagemagick: git7
           - php: 5.6
-            imagemagick: git7
-          - php: 5.5
             imagemagick: git7
 
     steps:
@@ -141,7 +114,7 @@ jobs:
           sudo apt-get install -y texlive-fonts-recommended || true
 
       - name: Cache ImageMagick
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-ImageMagick
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup PHP
         id: setup-php
-        uses: cmb69/setup-php-sdk@v0.2
+        uses: php/setup-php-sdk@v0.10
         with:
           version: ${{matrix.version}}
           arch: ${{matrix.arch}}

--- a/imagick.c
+++ b/imagick.c
@@ -603,7 +603,7 @@ static zval *php_imagick_read_property(zend_object *object, zend_string *member,
 					if (format) {
 						retval = rv;
 						ZVAL_STRING(retval, format);
-						php_strtolower(Z_STRVAL_P(retval), Z_STRLEN_P(retval));
+						zend_str_tolower(Z_STRVAL_P(retval), Z_STRLEN_P(retval));
 						IMAGICK_FREE_MAGICK_MEMORY(format);
 					} else {
 						retval = rv;
@@ -676,7 +676,7 @@ static zval *php_imagick_read_property(zval *object, zval *member, int type, voi
 					if (format) {
 						retval = rv;
 						ZVAL_STRING(retval, format);
-						php_strtolower(Z_STRVAL_P(retval), Z_STRLEN_P(retval));
+						zend_str_tolower(Z_STRVAL_P(retval), Z_STRLEN_P(retval));
 						IMAGICK_FREE_MAGICK_MEMORY(format);
 					} else {
 						retval = rv;
@@ -759,7 +759,7 @@ static zval *php_imagick_read_property(zval *object, zval *member, int type, con
 
 					if (format) {
 						ZVAL_STRING(retval, format, 1);
-						php_strtolower(Z_STRVAL_P(retval), Z_STRLEN_P(retval));
+						zend_str_tolower(Z_STRVAL_P(retval), Z_STRLEN_P(retval));
 						IMAGICK_FREE_MAGICK_MEMORY(format);
 					} else {
 						ZVAL_STRING(retval, "", 1);

--- a/imagick_helpers.c
+++ b/imagick_helpers.c
@@ -23,6 +23,25 @@
 #include "php_imagick_macros.h"
 #include "php_imagick_helpers.h"
 
+#define EXTRACT_BUILD_NUMBER(str) ({ \
+    int build = 0; \
+    const char *s = str; \
+    while (*s && !isdigit(*s)) s++; \
+    if (*s) build = atoi(s); \
+    build; \
+})
+
+#define MAGICK_LIB_VERSION_MAJOR ((MagickLibVersion >> 8) & 0xFF)
+#define MAGICK_LIB_VERSION_MINOR ((MagickLibVersion >> 4) & 0xF)
+#define MAGICK_LIB_VERSION_PATCH (MagickLibVersion & 0xF)
+#define MAGICK_LIB_VERSION_BUILD EXTRACT_BUILD_NUMBER(MagickLibAddendum)
+
+#define MAGICK_LIB_VERSION_GTE(major, minor, patch, build) \
+    ((VERSION_MAJOR > (major)) || \
+    (VERSION_MAJOR == (major) && VERSION_MINOR > (minor)) || \
+    (VERSION_MAJOR == (major) && VERSION_MINOR == (minor) && VERSION_PATCH > (patch)) || \
+    (VERSION_MAJOR == (major) && VERSION_MINOR == (minor) && VERSION_PATCH == (patch) && VERSION_BUILD >= (build)))
+
 MagickBooleanType php_imagick_progress_monitor(const char *text, const MagickOffsetType offset, const MagickSizeType span, void *client_data)
 {
 	FILE *fp;
@@ -1197,6 +1216,10 @@ void php_imagick_initialize_constants(TSRMLS_D)
 #if MagickLibVersion >= 0x707
 	IMAGICK_REGISTER_CONST_LONG("FILTER_CUBIC_SPLINE", CubicSplineFilter);
 #endif
+#if MAGICK_LIB_VERSION_GTE(7, 1, 1, 40)
+	IMAGICK_REGISTER_CONST_LONG("FILTER_MAGIC_KERNEL_SHARP_2013", MagicKernelSharp2013Filter);
+	IMAGICK_REGISTER_CONST_LONG("FILTER_MAGIC_KERNEL_SHARP_2021", MagicKernelSharp2021Filter);
+#endif
 	IMAGICK_REGISTER_CONST_LONG("IMGTYPE_UNDEFINED", UndefinedType);
 	IMAGICK_REGISTER_CONST_LONG("IMGTYPE_BILEVEL", BilevelType);
 	IMAGICK_REGISTER_CONST_LONG("IMGTYPE_GRAYSCALE", GrayscaleType);
@@ -1279,9 +1302,8 @@ void php_imagick_initialize_constants(TSRMLS_D)
 	IMAGICK_REGISTER_CONST_LONG("COMPRESSION_WEBP", WebPCompression);
 #endif
 
-#if MagickLibVersion >= 0x711
-	// Technically >= 7.1.0-13 but we still don't have a mechanism for
-	// detecting patch versions.
+// ImageMagick version >= 7.1.0-13
+#if MAGICK_LIB_VERSION_GTE(7, 1, 0, 13)
     IMAGICK_REGISTER_CONST_LONG("COMPRESSION_BC5", BC5Compression);
     IMAGICK_REGISTER_CONST_LONG("COMPRESSION_BC7", BC7Compression);
 #endif
@@ -1289,6 +1311,11 @@ void php_imagick_initialize_constants(TSRMLS_D)
 #if MagickLibVersion >= 0x70C
 	IMAGICK_REGISTER_CONST_LONG("COMPRESSION_DWAA", DWAACompression);
 	IMAGICK_REGISTER_CONST_LONG("COMPRESSION_DWAB", DWABCompression);
+#endif
+
+// ImageMagick version >= 7.1.1-16
+#if MAGICK_LIB_VERSION_GTE(7, 1, 1, 16)
+	IMAGICK_REGISTER_CONST_LONG("COMPRESSION_LERC", LERCCompression);
 #endif
 
 	IMAGICK_REGISTER_CONST_LONG("PAINT_POINT", PointMethod);
@@ -1553,6 +1580,11 @@ void php_imagick_initialize_constants(TSRMLS_D)
 	IMAGICK_REGISTER_CONST_LONG("COLORSPACE_JZAZBZ", JzazbzColorspace);
 #endif
 
+#if MAGICK_LIB_VERSION_GTE(7, 1, 1, 9)
+	IMAGICK_REGISTER_CONST_LONG("COLORSPACE_OKLAB", OklabColorspace);
+	IMAGICK_REGISTER_CONST_LONG("COLORSPACE_OKLCH", OklchColorspace);
+#endif
+
 	IMAGICK_REGISTER_CONST_LONG("VIRTUALPIXELMETHOD_UNDEFINED", UndefinedVirtualPixelMethod);
 	IMAGICK_REGISTER_CONST_LONG("VIRTUALPIXELMETHOD_BACKGROUND", BackgroundVirtualPixelMethod);
 #if MagickLibVersion < 0x700
@@ -1802,6 +1834,9 @@ void php_imagick_initialize_constants(TSRMLS_D)
 #if MagickLibVersion >= 0x700
 	IMAGICK_REGISTER_CONST_LONG("ALPHACHANNEL_OFF", OffAlphaChannel);
 #endif
+#if MAGICK_LIB_VERSION_GTE(7, 1, 1, 26)
+	IMAGICK_REGISTER_CONST_LONG("ALPHACHANNEL_OFF_IF_OPAQUE", OffIfOpaqueAlphaChannel);
+#endif
 	IMAGICK_REGISTER_CONST_LONG("ALPHACHANNEL_OPAQUE", OpaqueAlphaChannel);
 	IMAGICK_REGISTER_CONST_LONG("ALPHACHANNEL_SHAPE", ShapeAlphaChannel);
 	IMAGICK_REGISTER_CONST_LONG("ALPHACHANNEL_TRANSPARENT", TransparentAlphaChannel);
@@ -1948,6 +1983,10 @@ IMAGICK_REGISTER_CONST_LONG("KERNEL_BINOMIAL", BinomialKernel);
 /* Draw directions */
 IMAGICK_REGISTER_CONST_LONG("DIRECTION_LEFT_TO_RIGHT", LeftToRightDirection);
 IMAGICK_REGISTER_CONST_LONG("DIRECTION_RIGHT_TO_LEFT", RightToLeftDirection);
+
+#if MAGICK_LIB_VERSION_GTE(7, 1, 1, 14)
+    IMAGICK_REGISTER_CONST_LONG("DIRECTION_TOP_TO_BOTTOM", TopToBottomDirection);
+#endif
 
 // The kernel is scaled directly using given scaling factor without change.
 IMAGICK_REGISTER_CONST_LONG("NORMALIZE_KERNEL_NONE", 0);

--- a/tests/316_Imagick_getImageKurtosis.phpt
+++ b/tests/316_Imagick_getImageKurtosis.phpt
@@ -14,8 +14,19 @@ function getImageKurtosis() {
     $imagick = new \Imagick(__DIR__ . '/Biter_500.jpg');
     $values = $imagick->getImageKurtosis();
 
-    check_value($values, "kurtosis", -0.9379261035010518);
-    check_value($values, "skewness", 0.4562517200972045);
+    try {
+        check_value($values, "kurtosis", -0.9379261035010518);
+    } catch (\Exception $exception) {
+        // From version 7.1.1-24 the value of kurtosis is -0.7092599567492
+        check_value($values, "kurtosis", -0.7092599567492);
+    }
+
+    try {
+        check_value($values, "skewness", 0.4562517200972045);
+    } catch (\Exception $exception) {
+        // From version 7.1.1-24 the value of skewness is 0.56839010636614
+        check_value($values, "skewness", 0.56839010636614);
+    }
 }
 
 getImageKurtosis() ;

--- a/util/calculate_cflags.php
+++ b/util/calculate_cflags.php
@@ -70,6 +70,14 @@ else if ($PHP_VERSION == "5.6") {
     );
 }
 
-$result = implode(" ", $CFLAGS);
+// Problem with zend_*.h files on newer PHP builds
+if (in_array($PHP_VERSION, ['8.2', '8.3', '8.4'], true)) {
+    $CFLAGS = array_values(array_diff($CFLAGS, ['-Wdeclaration-after-statement']));
+}
+if (in_array($PHP_VERSION, ['8.4'], true)) {
+    $CFLAGS[] = "-Wno-missing-field-initializers";
+}
+
+$result = implode(" ", array_unique($CFLAGS));
 echo $result;
 fwrite(STDERR, "Ok. CFLAGS are: $result\n");

--- a/util/check_for_missing_enums.php
+++ b/util/check_for_missing_enums.php
@@ -159,9 +159,9 @@ else if (file_exists($directory.'/'.'MagickCore') == true) {
 			'VirtualPixelMethod',
 		],
 		'MagickCore/channel.h' => [
-            'AlphaChannelOption',
+			'AlphaChannelOption',
 		],
-        'MagickCore/compare.h' => [
+		'MagickCore/compare.h' => [
 			'MetricType',
 		],
 		'MagickCore/colorspace.h' => [

--- a/util/check_for_missing_enums.php
+++ b/util/check_for_missing_enums.php
@@ -158,7 +158,10 @@ else if (file_exists($directory.'/'.'MagickCore') == true) {
 		'MagickCore/cache-view.h' => [
 			'VirtualPixelMethod',
 		],
-		'MagickCore/compare.h' => [
+		'MagickCore/channel.h' => [
+            'AlphaChannelOption',
+		],
+        'MagickCore/compare.h' => [
 			'MetricType',
 		],
 		'MagickCore/colorspace.h' => [


### PR DESCRIPTION
* Fix skewness and kurtosis test after 7.1.1-24 calculation method change
* declare MAGICK_LIB_VERSION_GTE macro to help preprocessor code filtering
* replace `php_strtolower` wtih `zend_str_tolower` method calls due to deprecation in 8.4