### PR TITLE
Fix invalid val array check in trim

### DIFF
--- a/imagick_class.c
+++ b/imagick_class.c
@@ -8597,11 +8597,11 @@ void s_add_named_strings (zval *array, const char *haystack TSRMLS_DC)
 		line_string = zend_string_init(line, strlen(line), 0);
 		//str, what, what_len, mode
 		trim = php_trim(line_string, NULL, 0, 3);
-		for (i = 0; i < num_keys; i++) {
-			if (trim->val != NULL) {
-				if (strncmp (trim->val, str_keys [i], strlen (str_keys [i])) == 0) {
+		if (trim != NULL) {
+			for (i = 0; i < num_keys; i++) {
+				if (strncmp(ZSTR_VAL(trim), str_keys[i], strlen(str_keys[i])) == 0) {
 					// This should be our line
-					IM_add_assoc_string (array, arr_keys [i], trim->val + strlen (str_keys [i]));
+					IM_add_assoc_string(array, arr_keys[i], ZSTR_VAL(trim) + strlen(str_keys[i]));
 					found++;
 				}
 			}


### PR DESCRIPTION
This is related to pipeline failure: https://github.com/Imagick/imagick/actions/runs/13470981281/job/37644443027
```
/home/runner/work/imagick/imagick/imagick_class.c: In function 's_add_named_strings':
/home/runner/work/imagick/imagick/imagick_class.c:8601:39: error: the comparison will always evaluate as 'true' for the address of 'val' will never be NULL [-Werror=address]
 8601 |                         if (trim->val != NULL) {
      |                                       ^~
In file included from /usr/include/php/20230831/Zend/zend.h:27,
                 from /usr/include/php/20230831/main/php.h:32,
                 from /home/runner/work/imagick/imagick/php_imagick.h:42,
                 from /home/runner/work/imagick/imagick/imagick_class.c:21:
/usr/include/php/20230831/Zend/zend_types.h:377:27: note: 'val' declared here
  377 |         char              val[1];
      |                           ^~~
cc1: all warnings being treated as errors
make: *** [Makefile:213: imagick_class.lo] Error 1
Error: Process completed with exit code 2.
```