### PR TITLE
Switch windows workflow to php-windows-builder

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,49 +1,48 @@
 name: Build and Test on Windows
-on: [push]
+on:
+  push:
+  pull_request:
+  release:
+    types: [created]
 jobs:
-  windows:
-    defaults:
-      run:
-        shell: cmd
-    strategy:
-      matrix:
-        os: [windows-2019, windows-2022]
-        version: ["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
-        arch: [x64]
-        ts: [ts]
-        exclude:
-          - {os: windows-2019, version: "8.4"}
-          - {os: windows-2019, version: "8.3"}
-          - {os: windows-2019, version: "8.2"}
-          - {os: windows-2019, version: "8.1"}
-          - {os: windows-2019, version: "8.0"}
-          - {os: windows-2022, version: "7.4"}
-    runs-on: ${{matrix.os}}
+  get-extension-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.extension-matrix.outputs.matrix }}
     steps:
       - name: Checkout imagick
         uses: actions/checkout@v4
-      - name: Setup PHP
-        id: setup-php
-        uses: php/setup-php-sdk@v0.10
+      - name: Get the extension matrix
+        id: extension-matrix
+        uses: php/php-windows-builder/extension-matrix@v1
         with:
-          version: ${{matrix.version}}
-          arch: ${{matrix.arch}}
-          ts: ${{matrix.ts}}
-          cache: true
-      - name: Download deps
-        run: |
-          curl -LO https://downloads.php.net/~windows/pecl/deps/ImageMagick-7.1.0-18-vc15-${{matrix.arch}}.zip
-          7z x ImageMagick-7.1.0-18-vc15-${{matrix.arch}}.zip -o..\deps
-      - name: Enable Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@v1
+          php-version-list: '7.4, 8.0, 8.1, 8.2, 8.3, 8.4'
+
+  windows:
+    needs: get-extension-matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.get-extension-matrix.outputs.matrix)}}
+    steps:
+      - name: Checkout imagick
+        uses: actions/checkout@v4
+      - name: Build the extension
+        uses: php/php-windows-builder/extension@v1
         with:
-          arch: ${{matrix.arch}}
-          toolset: ${{steps.setup-php.outputs.toolset}}
-      - name: phpize
-        run: phpize
-      - name: configure
-        run: configure --with-imagick --with-php-build=..\deps --with-prefix=${{steps.setup-php.outputs.prefix}}
-      - name: make
-        run: nmake
-      - name: test
-        run: nmake test TESTS="-j4 --show-diff -g FAIL,BORK,WARN,LEAK tests"
+          php-version: ${{ matrix.php-version }}
+          arch: ${{ matrix.arch }}
+          ts: ${{ matrix.ts }}
+          libs: ImageMagick-7
+          test-workers: 4  
+
+  release:
+    runs-on: ubuntu-latest
+    needs: windows
+    if: ${{ github.event_name == 'release' }}
+    steps:
+      - name: Upload artifact to the release
+        uses: php/php-windows-builder/release@v1
+        with:
+          release: ${{ github.event.release.tag_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the windows workflow to use php-windows-builder.
Also, adds support to run on a new releases and add builds as release artifacts.

Example release: https://github.com/shivammathur/imagick/releases/tag/3.7.1