### PR TITLE
Fix `getImage(s)Blob()` return type

### DIFF
--- a/Imagick.stub.php
+++ b/Imagick.stub.php
@@ -495,7 +495,7 @@ class Imagick
 
     public function getImageSize(): int  {}
 
-    public function getImageBlob(): ?string  {}
+    public function getImageBlob(): string  {}
 
     public function getImagesBlob(): string  {}
 

--- a/Imagick_arginfo.h
+++ b/Imagick_arginfo.h
@@ -2002,14 +2002,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_Imagick_getImageSize arginfo_class_Imagick_getSizeOffset
 
-
-#if PHP_VERSION_ID >= 80000
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Imagick_getImageBlob, 0, 0, IS_STRING, 1)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Imagick_getImageBlob, 0, 0, 0)
-#endif
-
-ZEND_END_ARG_INFO()
+#define arginfo_class_Imagick_getImageBlob arginfo_class_Imagick___toString
 
 #define arginfo_class_Imagick_getImagesBlob arginfo_class_Imagick___toString
 

--- a/imagick_class.c
+++ b/imagick_class.c
@@ -8475,7 +8475,8 @@ PHP_METHOD(Imagick, getImagesBlob)
 
 	image_contents = MagickGetImagesBlob(intern->magick_wand, &image_size);
 	if (!image_contents) {
-		return;
+		php_imagick_throw_exception(IMAGICK_CLASS, "Failed to get the image contents (empty or invalid image?)" TSRMLS_CC);
+		RETURN_THROWS();
 	}
 
 	IM_ZVAL_STRINGL(return_value, (char *)image_contents, image_size);

--- a/package.xml
+++ b/package.xml
@@ -406,6 +406,7 @@ This extension requires ImageMagick version 6.5.3-10+ and PHP 5.6.0+.
 				<file name="328_Imagick_polaroidImageWithTextAndMethod_basic.phpt" role="test" />
 				<file name="329_imagick_getImageBlob_empty.phpt" role="test" />
 				<file name="330_Imagick_newImage.phpt" role="test" />
+				<file name="331_Imagick_getImagesBlob_empty.phpt" role="test" />
 				<file name="bug20636.phpt" role="test" />
 				<file name="bug21229.phpt" role="test" />
 				<file name="bug59378.phpt" role="test" />

--- a/tests/331_Imagick_getImagesBlob_empty.phpt
+++ b/tests/331_Imagick_getImagesBlob_empty.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Imagick::getImagesBlob behaviour on invalid images
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc'); ?>
+--FILE--
+<?php
+
+// Fails due to image having no format
+$imagick = new Imagick();
+try {
+	$imagick->newPseudoImage(200, 200, "xc:red");
+	$result = $imagick->getImagesBlob();
+	echo "Imagick failed to throw exception" . PHP_EOL;
+} catch (ImagickException $e) {
+	echo "ImagickException: " . $e->getMessage() . PHP_EOL;
+}
+
+echo "Fin.\n";
+
+?>
+--EXPECTF--
+ImagickException: Failed to get the image contents (empty or invalid image?)
+Fin.


### PR DESCRIPTION
PR #616 defined the return type of `getImageBlob()` as nullable, but that is no longer correct because PR #606 changed it to throw an exception instead of returning null.

This PR sets the return type of `getImageBlob()` back to non-nullable and updates `getImagesBlob()` to throw an exception when it fails to get the image contents. This makes both methods behave consistently.