### PR TITLE
Relax version check to ignore micro versions

### DIFF
--- a/imagick.c
+++ b/imagick.c
@@ -954,7 +954,7 @@ static void checkImagickVersion()
 
 	GetMagickVersion(&imageMagickLibraryVersion);
 
-	if (imagickVersion == imageMagickLibraryVersion) {
+	if ((imagickVersion >= imageMagickLibraryVersion) && ((imagickVersion - imageMagickLibraryVersion) < 0x010)) {
 		return;
 	}
 


### PR DESCRIPTION
As is, imagick complains if the ImageMagick version mismatches even slightly. This means that while patches will not change the version, `micro` changes to the ImageMagick version will cause this. There's a discussion at [Arch](https://gitlab.archlinux.org/archlinux/packaging/packages/php-imagick/-/issues/3) about this situation, considering it forces a rebuild of `php-imagick` on every single minor version change or it will print the warning message.

Yet, [upstream](https://github.com/ImageMagick/ImageMagick/blob/main/m4/version.m4) declares that changes to the `micro` part of the version are backwards compatible:

>  3. MICRO version for added functionality in backwards compatible manner, and

For this reason, Arch carries a [patch](https://gitlab.archlinux.org/archlinux/packaging/packages/php-imagick/-/blob/main/php-imagick-3.7.0-skip_version_check_by_default.patch?ref_type=heads) to disable the version check by default, as the constant new micro versions of ImageMagick do not interfere with the functionality yet require a rebuilt lest the warning is shown.

It's obviously not great to have to change this behaviour, and so I suggest this patch to relax the check: Instead of comparing the exact version, this checks if the `imagickVersion` is newer by less than a `minor` version, ignoring the `micro` part. `php-imagick` cannot immediately profit from newer functionality by a `micro` change, and there is no concern about backwards compatibility if the ImageMagick version is only newer by a `micro` version.