### PR TITLE
use Zend/zend_smart_string.h

### DIFF
--- a/imagick.c
+++ b/imagick.c
@@ -24,7 +24,9 @@
 #include "php_imagick_helpers.h"
 #include "php_imagick_shared.h"
 
-#if PHP_VERSION_ID >= 70000
+#if PHP_VERSION_ID >= 70200
+#include "Zend/zend_smart_string.h"
+#elif PHP_VERSION_ID >= 70000
 #include "ext/standard/php_smart_string.h"
 #else
 #include "ext/standard/php_smart_str.h"


### PR DESCRIPTION
* `Zend/zend_smart_string.h` exists since 7.2
* `ext/standard/php_smart_string.h` removed in 8.5.0alpha3
