### PR TITLE
Fix format specifier warning in importImagePixels

### DIFF
--- a/imagick_class.c
+++ b/imagick_class.c
@@ -2425,7 +2425,7 @@ PHP_METHOD(Imagick, importImagePixels)
 			php_imagick_exception_class_entry,
 				0,
 #if PHP_VERSION_ID >= 70000
-				"The map contains incorrect number of elements. Expected %ld, array has %u",
+				"The map contains incorrect number of elements. Expected %zu, array has %u",
 #else
 				"The map contains incorrect number of elements. Expected %ld, array has %d",
 #endif


### PR DESCRIPTION
Changed %ld to %zu for PHP_VERSION_ID >= 70000, coz map_len is size_t now