### PR TITLE
The zval_dtor() alias of zval_ptr_dtor_nogc() has been removed in php 8.6 (master)

### DIFF
--- a/imagick.c
+++ b/imagick.c
@@ -704,7 +704,7 @@ static zval *php_imagick_read_property(zval *object, zval *member, int type, voi
 	}
 
 	if (member == &tmp_member) {
-		zval_dtor(member);
+		zval_ptr_dtor_nogc(member);
 	}
 
 	return retval;
@@ -778,7 +778,7 @@ static zval *php_imagick_read_property(zval *object, zval *member, int type, con
 		}
 	}
 	if (member == &tmp_member) {
-    	zval_dtor(member);
+    	zval_ptr_dtor_nogc(member);
     }
 
 	if (!retval) {

--- a/imagick_helpers.c
+++ b/imagick_helpers.c
@@ -323,7 +323,7 @@ double *php_imagick_zval_to_double_array(zval *param_array, im_long *num_element
 			convert_to_double(tmp_pzval);
 
 			value = Z_DVAL_P(tmp_pzval);
-			zval_dtor (tmp_pzval);
+			zval_ptr_dtor_nogc (tmp_pzval);
 		}
 		double_array[i] = value;
 	}
@@ -374,7 +374,7 @@ im_long *php_imagick_zval_to_long_array(zval *param_array, im_long *num_elements
 			convert_to_long(tmp_pzval);
 
 			value = Z_LVAL_P(tmp_pzval);
-			zval_dtor (tmp_pzval);
+			zval_ptr_dtor_nogc (tmp_pzval);
 		}
 		long_array[i] = value;
 	}
@@ -425,7 +425,7 @@ unsigned char *php_imagick_zval_to_char_array(zval *param_array, im_long *num_el
 			convert_to_long(tmp_pzval);
 
 			value = Z_LVAL_P(tmp_pzval);
-			zval_dtor (tmp_pzval);
+			zval_ptr_dtor_nogc (tmp_pzval);
 		}
 		char_array[i] = value;
 	}


### PR DESCRIPTION
Hi. Tried building against php master branch and this issue jumped out.  
php [UPGRADING.INTERNALS](https://github.com/php/php-src/blob/f35a497b9db9daca292999838044d82c437602c9/UPGRADING.INTERNALS#L35) says: "The zval_dtor() alias of zval_ptr_dtor_nogc() has been removed. Call zval_ptr_dtor_nogc() directly instead.".  
So as this is purely removed alias, this seems to be a trivial fix