### PR TITLE
Fix version for pie installation

### DIFF
--- a/php_imagick.h
+++ b/php_imagick.h
@@ -23,9 +23,7 @@
 
 /* Define Extension Properties */
 #define PHP_IMAGICK_EXTNAME    "imagick"
-// The version is deliberately left as 'PACKAGE_VERSION' in source code.
-// It is only replaced with the actual version number that packaged through pecl.php.net
-#define PHP_IMAGICK_VERSION    "@PACKAGE_VERSION@"
+#define PHP_IMAGICK_VERSION    "3.8.1"
 #define PHP_IMAGICK_EXTNUM     30801
 
 /* Import configure options when building 


### PR DESCRIPTION
When installed using **pie**
```

$ php --ri imagick

imagick

imagick module => enabled
imagick module version => @PACKAGE_VERSION@
...
```

In package.xml there is 
```
			<file name="php_imagick.h" role="src">
				<tasks:replace from="@PACKAGE_VERSION@" to="version" type="package-info" />
			</file>
```
But this is only for **pecl**


Notice: not much a big work on release, as `PHP_IMAGICK_EXTNUM` already has to be updated manually