### PR TITLE
Fix memory leak in Imagick::colorThresholdImage()

### DIFF
--- a/imagick_class.c
+++ b/imagick_class.c
@@ -13492,8 +13492,12 @@ PHP_METHOD(Imagick, colorThresholdImage)
 		return;
 
 	stop_color_wand = php_imagick_zval_to_pixelwand (stop_color_param, IMAGICK_CLASS, &stop_color_allocated TSRMLS_CC);
-	if (!stop_color_wand)
+	if (!stop_color_wand) {
+		if (start_color_allocated)
+			start_color_wand = DestroyPixelWand (start_color_wand);
+
 		return;
+	}
 
 	status = MagickColorThresholdImage(
 		intern->magick_wand,

--- a/package.xml
+++ b/package.xml
@@ -390,6 +390,7 @@ This extension requires ImageMagick version 6.5.3-10+ and PHP 5.6.0+.
 				<file name="310_Imagick_whiteBalanceImage.phpt" role="test" />
 				<file name="311_Imagick_channelFxImage.phpt" role="test" />
 				<file name="312_Imagick_colorThresholdImage.phpt" role="test" />
+				<file name="313_Imagick_colorThresholdImage_invalid.phpt" role="test" />
 				<file name="314_Imagick_getBackgroundColor.phpt" role="test" />
 				<file name="315_Imagick_getImageArtifacts.phpt" role="test" />
 				<file name="316_Imagick_getImageKurtosis.phpt" role="test" />

--- a/tests/313_Imagick_colorThresholdImage_invalid.phpt
+++ b/tests/313_Imagick_colorThresholdImage_invalid.phpt
@@ -16,7 +16,7 @@ function colorThresholdImage() {
             "complete garbage"
         );
     } catch (ImagickException $e) {
-        echo $e::class, ": ", $e->getMessage(), "\n";
+        echo "ImagickException: ", $e->getMessage(), "\n";
     }
 }
 

--- a/tests/313_Imagick_colorThresholdImage_invalid.phpt
+++ b/tests/313_Imagick_colorThresholdImage_invalid.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Test Imagick, colorThresholdImage invalid input
+--SKIPIF--
+<?php
+require_once(dirname(__FILE__) . '/skipif.inc');
+checkClassMethods('Imagick', array('colorThresholdImage'));
+?>
+--FILE--
+<?php
+
+function colorThresholdImage() {
+    $imagick = new \Imagick(__DIR__ . '/Biter_500.jpg');
+    try {
+        $imagick->colorThresholdImage(
+            "rgb(10, 10, 10)",
+            "complete garbage"
+        );
+    } catch (ImagickException $e) {
+        echo $e::class, ": ", $e->getMessage(), "\n";
+    }
+}
+
+colorThresholdImage() ;
+?>
+--EXPECTF--
+ImagickException: Unrecognized color string


### PR DESCRIPTION
When `stop_color_wand` is invalid but `start_color_wand` was valid, this will leak memory:

```
Indirect leak of 56 byte(s) in 1 object(s) allocated from:
    #0 0x7f1f8c72c161 in malloc (/usr/lib/libasan.so.8+0x12c161) (BuildId: ee5fbab73143ab257a66a33afe0f038a4af7a74e)
    #1 0x7b1f857441ed in AcquireCriticalMemory (/usr/lib/libMagickCore-7.Q16HDRI.so.10+0x1441ed) (BuildId: 37b980917ab6f85c1f92a6f03b43ca060849d66a)
    #2 0x7b1f8570be36 in AcquireExceptionInfo (/usr/lib/libMagickCore-7.Q16HDRI.so.10+0x10be36) (BuildId: 37b980917ab6f85c1f92a6f03b43ca060849d66a)
    #3 0x7b1f8819e024 in NewPixelWand (/usr/lib/libMagickWand-7.Q16HDRI.so.10+0x116024) (BuildId: c2b7b6550e6b44c7df1bc48cfa004cb88fe60627)
    #4 0x7f1f889cbee6 in php_imagick_zval_to_pixelwand /run/media/niels/MoreData/imagick/imagick_helpers.c:787
    #5 0x7f1f889bad88 in zim_Imagick_colorThresholdImage /run/media/niels/MoreData/imagick/imagick_class.c:13490
    #6 0x563184fcea2e in ZEND_DO_FCALL_SPEC_RETVAL_UNUSED_HANDLER /run/media/niels/MoreData/php-8.4/Zend/zend_vm_execute.h:1907
    #7 0x56318512daed in execute_ex /run/media/niels/MoreData/php-8.4/Zend/zend_vm_execute.h:58947
    #8 0x563185141866 in zend_execute /run/media/niels/MoreData/php-8.4/Zend/zend_vm_execute.h:64334
    #9 0x5631852a6ef8 in zend_execute_script /run/media/niels/MoreData/php-8.4/Zend/zend.c:1934
    #10 0x563184cf0fdb in php_execute_script_ex /run/media/niels/MoreData/php-8.4/main/main.c:2577
    #11 0x563184cf148f in php_execute_script /run/media/niels/MoreData/php-8.4/main/main.c:2617
    #12 0x5631852ac7e1 in do_cli /run/media/niels/MoreData/php-8.4/sapi/cli/php_cli.c:935
    #13 0x5631852ae792 in main /run/media/niels/MoreData/php-8.4/sapi/cli/php_cli.c:1322
    #14 0x7f1f8b827740  (/usr/lib/libc.so.6+0x27740) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #15 0x7f1f8b827878 in __libc_start_main (/usr/lib/libc.so.6+0x27878) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #16 0x563184205974 in _start (/usr/local/bin/php+0x605974) (BuildId: 69a1283cc37add59b1680b36e9f3ae4f04a82277)
```

Note: this was found by a hybrid static-dynamic analyzer I'm developing.