### PR TITLE
Fix memory leaks when MagickExportImagePixels() fails

### DIFF
--- a/imagick_class.c
+++ b/imagick_class.c
@@ -2717,6 +2717,7 @@ PHP_METHOD(Imagick, exportImagePixels)
 				efree(float_array);
 				return;
 			}
+			efree(float_array);
 		break;
 
 		case DoublePixel:
@@ -2731,6 +2732,7 @@ PHP_METHOD(Imagick, exportImagePixels)
 				efree(double_array);
 				return;
 			}
+			efree(double_array);
 		break;
 
 		case ShortPixel:
@@ -2745,6 +2747,7 @@ PHP_METHOD(Imagick, exportImagePixels)
 				efree(short_array);
 				return;
 			}
+			efree(short_array);
 		break;
 
 #if MagickLibVersion >= 0x700
@@ -2765,6 +2768,7 @@ PHP_METHOD(Imagick, exportImagePixels)
 				efree(longlong_array);
 				return;
 			}
+			efree(longlong_array);
 		break;
 #endif
 
@@ -2783,6 +2787,7 @@ PHP_METHOD(Imagick, exportImagePixels)
 				efree(long_array);
 				return;
 			}
+			efree(long_array);
 		break;
 
 		case CharPixel:
@@ -2797,6 +2802,7 @@ PHP_METHOD(Imagick, exportImagePixels)
 				efree(char_array);
 				return;
 			}
+			efree(char_array);
 		break;
 
 		case QuantumPixel:
@@ -2815,6 +2821,7 @@ PHP_METHOD(Imagick, exportImagePixels)
 				efree(quantum_array);
 				return;
 			}
+			efree(quantum_array);
 		break;
 
 		default:


### PR DESCRIPTION
The failure was already checked and handled, but the allocated memory was not freed.
Example ASAN report:
```
Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7f81465bf9c7 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x5bb1ab2adec5 in tracked_malloc /work/php-src/Zend/zend_alloc.c:3018
    #2 0x5bb1ab2ace29 in _emalloc /work/php-src/Zend/zend_alloc.c:2780
    #3 0x7f814122df7b in zim_Imagick_exportImagePixels /work/php-imagemagick/imagick_class.c:2709
    #4 0x5bb1ab0c9395 in zend_test_execute_internal /work/php-src/ext/zend_test/observer.c:306
    #5 0x5bb1ab3f170a in ZEND_DO_FCALL_SPEC_RETVAL_USED_HANDLER /work/php-src/Zend/zend_vm_execute.h:2154
    #6 0x5bb1ab551e55 in execute_ex /work/php-src/Zend/zend_vm_execute.h:116519
    #7 0x5bb1ab566d70 in zend_execute /work/php-src/Zend/zend_vm_execute.h:121962
    #8 0x5bb1ab6cb56b in zend_execute_script /work/php-src/Zend/zend.c:1980
    #9 0x5bb1ab0fdd7b in php_execute_script_ex /work/php-src/main/main.c:2645
    #10 0x5bb1ab0fe18b in php_execute_script /work/php-src/main/main.c:2685
    #11 0x5bb1ab6d10d6 in do_cli /work/php-src/sapi/cli/php_cli.c:951
    #12 0x5bb1ab6d36a3 in main /work/php-src/sapi/cli/php_cli.c:1362
    #13 0x7f814589d1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #14 0x7f814589d28a in __libc_start_main_impl ../csu/libc-start.c:360
    #15 0x5bb1aa209df4 in _start (/work/php-src/build-dbg-asan/sapi/cli/php+0x609df4) (BuildId: 97494815ba6ad97379608f28619e331873dc4434)

SUMMARY: AddressSanitizer: 16 byte(s) leaked in 1 allocation(s).
```

Note: this was found by a hybrid static-dynamic analyzer I'm developing.