### PR TITLE
Fix memory leak with fonts returned from MagickQueryFonts()

### DIFF
--- a/imagick_helpers.c
+++ b/imagick_helpers.c
@@ -452,6 +452,10 @@ zend_bool php_imagick_check_font(char *font, int font_len TSRMLS_DC)
 		}
 	}
 
+	for(i = 0 ; i < num_fonts ; i++) {
+		IMAGICK_FREE_MAGICK_MEMORY(fonts[i]);
+	}
+
 	IMAGICK_FREE_MAGICK_MEMORY(fonts);
 	return retval;
 }


### PR DESCRIPTION
The correct usage is to also free the strings from the array as shown in `PHP_METHOD(Imagick, queryFonts)`.

ASAN report:
```
Direct leak of 2066 byte(s) in 109 object(s) allocated from:
    #0 0x700f9cafe9c7 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x700f965ada48 in ConstantString MagickCore/string.c:692
    #2 0x700f965c32b0 in GetTypeList MagickCore/type.c:680
    #3 0x700f96961ce3 in MagickQueryFonts MagickWand/magick-wand.c:716
    #4 0x700f9784d1fe in php_imagick_check_font /work/php-imagemagick/imagick_helpers.c:445
    #5 0x700f9782cc27 in zim_ImagickDraw_setFont /work/php-imagemagick/imagickdraw_class.c:556
    #6 0x61b6d96c9395 in zend_test_execute_internal /work/php-src/ext/zend_test/observer.c:306
    #7 0x61b6d99f08bb in ZEND_DO_FCALL_SPEC_RETVAL_UNUSED_HANDLER /work/php-src/Zend/zend_vm_execute.h:2024
    #8 0x61b6d9b51e07 in execute_ex /work/php-src/Zend/zend_vm_execute.h:116514
    #9 0x61b6d9b66d70 in zend_execute /work/php-src/Zend/zend_vm_execute.h:121962
    #10 0x61b6d9ccb56b in zend_execute_script /work/php-src/Zend/zend.c:1980
    #11 0x61b6d96fdd7b in php_execute_script_ex /work/php-src/main/main.c:2645
    #12 0x61b6d96fe18b in php_execute_script /work/php-src/main/main.c:2685
    #13 0x61b6d9cd10d6 in do_cli /work/php-src/sapi/cli/php_cli.c:951
    #14 0x61b6d9cd36a3 in main /work/php-src/sapi/cli/php_cli.c:1362
    #15 0x700f9bddc1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #16 0x700f9bddc28a in __libc_start_main_impl ../csu/libc-start.c:360
    #17 0x61b6d8809df4 in _start (/work/php-src/build-dbg-asan/sapi/cli/php+0x609df4) (BuildId: 97494815ba6ad97379608f28619e331873dc4434)

SUMMARY: AddressSanitizer: 2066 byte(s) leaked in 109 allocation(s).
```

Note: this was found by a hybrid static-dynamic analyzer I'm developing.