### PR TITLE
Fix memory leak in colorMatrixImage()

### DIFF
--- a/imagick_class.c
+++ b/imagick_class.c
@@ -12422,11 +12422,6 @@ PHP_METHOD(Imagick, colorMatrixImage)
 	status = MagickColorMatrixImage(intern->magick_wand, kernel_color_matrix);
 
 	//Free the memory
-#if MagickLibVersion >= 0x700
-	kernel_color_matrix->values = (MagickRealType *) NULL;
-#else
-	kernel_color_matrix->values = (double *) NULL;
-#endif
 	kernel_color_matrix = DestroyKernelInfo(kernel_color_matrix);
 	efree(colors);
 


### PR DESCRIPTION
Pointer was set to NULL but not freed.
Cast is not necessary so a common path can be used for both versions.

ASAN report:
```
Direct leak of 200 byte(s) in 1 object(s) allocated from:
    #0 0x7b125dc32f1d in posix_memalign ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7b12577146aa in AcquireAlignedMemory_POSIX MagickCore/memory.c:277
    #2 0x7b12577146aa in AcquireAlignedMemory MagickCore/memory.c:355
    #3 0x7b1258a19ec1 in php_imagick_getKernelInfo /work/php-imagemagick/imagick_class.c:12365
    #4 0x7b1258a1a476 in zim_Imagick_colorMatrixImage /work/php-imagemagick/imagick_class.c:12419
    #5 0x64fcc52c9395 in zend_test_execute_internal /work/php-src/ext/zend_test/observer.c:306
    #6 0x64fcc55f08bb in ZEND_DO_FCALL_SPEC_RETVAL_UNUSED_HANDLER /work/php-src/Zend/zend_vm_execute.h:2024
    #7 0x64fcc5751e07 in execute_ex /work/php-src/Zend/zend_vm_execute.h:116514
    #8 0x64fcc5766d70 in zend_execute /work/php-src/Zend/zend_vm_execute.h:121962
    #9 0x64fcc58cb56b in zend_execute_script /work/php-src/Zend/zend.c:1980
    #10 0x64fcc52fdd7b in php_execute_script_ex /work/php-src/main/main.c:2645
    #11 0x64fcc52fe18b in php_execute_script /work/php-src/main/main.c:2685
    #12 0x64fcc58d10d6 in do_cli /work/php-src/sapi/cli/php_cli.c:951
    #13 0x64fcc58d36a3 in main /work/php-src/sapi/cli/php_cli.c:1362
    #14 0x7b125cf111c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #15 0x7b125cf1128a in __libc_start_main_impl ../csu/libc-start.c:360
    #16 0x64fcc4409df4 in _start (/work/php-src/build-dbg-asan/sapi/cli/php+0x609df4) (BuildId: 97494815ba6ad97379608f28619e331873dc4434)
```

Note: this was found by a hybrid static-dynamic analyzer I'm developing.