### PR TITLE
Fix memory leak in polynomialImage()

### DIFF
--- a/imagick_class.c
+++ b/imagick_class.c
@@ -14088,8 +14088,6 @@ PHP_METHOD(Imagick, polynomialImage)
 		RETURN_THROWS();
 	}
 
-	terms_double_array = php_imagick_zval_to_double_array(terms, &terms_count TSRMLS_CC);
-
 	intern = Z_IMAGICK_P(getThis());
 	IMAGICK_NOT_EMPTY(intern);
 
@@ -14098,6 +14096,8 @@ PHP_METHOD(Imagick, polynomialImage)
 		php_imagick_convert_imagick_exception(intern->magick_wand, "Unable to polynomialImage, failed to set iterator to zero" TSRMLS_CC);
 		RETURN_THROWS();
 	}
+
+	terms_double_array = php_imagick_zval_to_double_array(terms, &terms_count TSRMLS_CC);
 
 	// TODO - sanity check terms_count
 


### PR DESCRIPTION
`terms_double_array` is freed on other paths but not the `MagickSetIteratorIndex` error path.
Furthermore, `IMAGICK_NOT_EMPTY(intern)` can return early too.
Move the allocation to avoid these 2 issues.

ASAN report:
```
Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x758c39ce19c7 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x6463c64adec5 in tracked_malloc /work/php-src/Zend/zend_alloc.c:3018
    #2 0x6463c64ace29 in _emalloc /work/php-src/Zend/zend_alloc.c:2780
    #3 0x6463c64ad33d in _ecalloc /work/php-src/Zend/zend_alloc.c:2847
    #4 0x758c34a4c9f6 in php_imagick_zval_to_double_array /work/php-imagemagick/imagick_helpers.c:300
    #5 0x758c34a26fbc in zim_Imagick_polynomialImage /work/php-imagemagick/imagick_class.c:14091
    #6 0x6463c62c9395 in zend_test_execute_internal /work/php-src/ext/zend_test/observer.c:306
    #7 0x6463c65f08bb in ZEND_DO_FCALL_SPEC_RETVAL_UNUSED_HANDLER /work/php-src/Zend/zend_vm_execute.h:2024
    #8 0x6463c6751e07 in execute_ex /work/php-src/Zend/zend_vm_execute.h:116514
    #9 0x6463c6766d70 in zend_execute /work/php-src/Zend/zend_vm_execute.h:121962
    #10 0x6463c68cb56b in zend_execute_script /work/php-src/Zend/zend.c:1980
    #11 0x6463c62fdd7b in php_execute_script_ex /work/php-src/main/main.c:2645
    #12 0x6463c62fe18b in php_execute_script /work/php-src/main/main.c:2685
    #13 0x6463c68d10d6 in do_cli /work/php-src/sapi/cli/php_cli.c:951
    #14 0x6463c68d36a3 in main /work/php-src/sapi/cli/php_cli.c:1362
    #15 0x758c38fbf1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #16 0x758c38fbf28a in __libc_start_main_impl ../csu/libc-start.c:360
    #17 0x6463c5409df4 in _start (/work/php-src/build-dbg-asan/sapi/cli/php+0x609df4) (BuildId: 97494815ba6ad97379608f28619e331873dc4434)
```

Note: this was found by a hybrid static-dynamic analyzer I'm developing.