### PR TITLE
Fix missing check for MagickGetImageBlob()

### DIFF
--- a/imagick_class.c
+++ b/imagick_class.c
@@ -3371,6 +3371,10 @@ PHP_METHOD(Imagick, __toString)
 	}
 
 	image = MagickGetImageBlob(intern->magick_wand, &image_size);
+	if (!image) {
+		php_imagick_throw_exception(IMAGICK_CLASS, "Failed to get the image contents (empty or invalid image?)" TSRMLS_CC);
+		RETURN_THROWS();
+	}
 	IM_ZVAL_STRINGL(return_value, (char *)image, image_size);
 	IMAGICK_FREE_MAGICK_MEMORY(image);
 }


### PR DESCRIPTION
This mimicks the other check.
Otherwise you risk UB/ASAN issue:
```
==299531==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x75b165aa4a01 bp 0x7ffd2136b390 sp 0x7ffd2136b358 T0)
==299531==The signal is caused by a READ memory access.
==299531==Hint: address points to the zero page.
    #0 0x75b165aa4a01 in __memmove_avx_unaligned ../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:220
    #1 0x75b1613b84db in zend_string_init /usr/local/include/php/Zend/zend_string.h:191
    #2 0x75b1613d3fa6 in zim_Imagick___toString /work/php-imagemagick/imagick_class.c:3374
    #3 0x57771ccc9395 in zend_test_execute_internal /work/php-src/ext/zend_test/observer.c:306
    #4 0x57771cfb2943 in zend_call_function /work/php-src/Zend/zend_execute_API.c:1024
    #5 0x57771cfb3604 in zend_call_known_function /work/php-src/Zend/zend_execute_API.c:1103
    #6 0x57771d24a100 in zend_call_known_instance_method /work/php-src/Zend/zend_API.h:860
    #7 0x57771d24a13a in zend_call_known_instance_method_with_0_params /work/php-src/Zend/zend_API.h:866
    #8 0x57771d25cbea in zend_std_cast_object_tostring /work/php-src/Zend/zend_object_handlers.c:2457
    #9 0x57771ceba6ec in zend_parse_arg_str_weak /work/php-src/Zend/zend_API.c:742
    #10 0x57771d0fb398 in ZEND_STRLEN_SPEC_CV_HANDLER /work/php-src/Zend/zend_vm_execute.h:42699
    #11 0x57771d16243b in execute_ex /work/php-src/Zend/zend_vm_execute.h:120755
    #12 0x57771d166d70 in zend_execute /work/php-src/Zend/zend_vm_execute.h:121962
    #13 0x57771d2cb56b in zend_execute_script /work/php-src/Zend/zend.c:1980
    #14 0x57771ccfdd7b in php_execute_script_ex /work/php-src/main/main.c:2645
    #15 0x57771ccfe18b in php_execute_script /work/php-src/main/main.c:2685
    #16 0x57771d2d10d6 in do_cli /work/php-src/sapi/cli/php_cli.c:951
    #17 0x57771d2d36a3 in main /work/php-src/sapi/cli/php_cli.c:1362
    #18 0x75b1659461c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #19 0x75b16594628a in __libc_start_main_impl ../csu/libc-start.c:360
    #20 0x57771be09df4 in _start (/work/php-src/build-dbg-asan/sapi/cli/php+0x609df4) (BuildId: 97494815ba6ad97379608f28619e331873dc4434)
```

If an exception is thrown via `__toString()` in PHP 5.x, it will end the request via a fatal error, which seems fine for those versions.

Note: this was found by a hybrid static-dynamic analyzer I'm developing.