### PR TITLE
Propagate error from MagickEvaluateImages()

### DIFF
--- a/imagick_class.c
+++ b/imagick_class.c
@@ -6481,6 +6481,10 @@ PHP_METHOD(Imagick, evaluateImages)
 	}
 
 	evaluated_wand = MagickEvaluateImages(intern->magick_wand, evaluate_operator);
+	if (evaluated_wand == NULL) {
+		php_imagick_convert_imagick_exception(intern->magick_wand, "Evaluating images failed" TSRMLS_CC);
+		RETURN_THROWS();
+	}
 
 	object_init_ex(return_value, php_imagick_sc_entry);
 	intern_return = Z_IMAGICK_P(return_value);


### PR DESCRIPTION
Matches other code.

Note: this was found by a hybrid static-dynamic analyzer I'm developing.